### PR TITLE
Local dev + file transfer + Turnstile; fix relay bug; Cloudflare docs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "elm-chat-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a reproducible problem (NOT a security vulnerability)
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+> ⚠️ **Do not report security vulnerabilities here.** See [SECURITY.md](../../SECURITY.md) for private disclosure.
+
+## Describe the bug
+
+A clear, concise description of what's wrong.
+
+## To reproduce
+
+1. Go to '...'
+2. Create a room with '...' settings
+3. Click on '...'
+4. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Screenshots / console output
+
+If applicable. **Redact any room secrets, invite tokens, or message content.**
+
+## Environment
+
+- Device / OS:
+- Browser + version:
+- Self-hosted or the public instance?
+- Commit / version (if known):
+
+## Additional context
+
+Anything else relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/shawnbure/elm-chat/security/advisories/new
+    about: Please report vulnerabilities privately — do NOT open a public issue.
+  - name: 💬 Questions & design discussion
+    url: https://github.com/shawnbure/elm-chat/discussions
+    about: Ask questions, propose protocol changes, and discuss threat models here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## The problem
+
+What are you trying to do that's hard or impossible today?
+
+## Proposed solution
+
+What you'd like to see.
+
+## Privacy check
+
+elm.chat's core promise is minimal server trust and no recoverable history. Please address:
+
+- Does this proposal require the server to see, log, or retain anything new?
+- Could it be used to deanonymize participants or reconstruct a transcript?
+- Is there a privacy-preserving way to achieve the same goal?
+
+## Alternatives considered
+
+Other approaches you thought about.
+
+## Additional context
+
+Mockups, links, prior art, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thanks for contributing to elm.chat! Keep PRs scoped to a single concern. -->
+
+## What does this change?
+
+<!-- A clear, concise description of the change and the motivation. -->
+
+## Security & privacy impact
+
+<!-- REQUIRED. Answer honestly: -->
+
+- Does this change what the **server** can see, log, or retain? 
+- Does it add or alter any data that could deanonymize a participant or reconstruct a transcript?
+- Does it touch encryption, key exchange, secret handling, or access control?
+
+<!-- If "no" to all, say so explicitly. If "yes", explain the tradeoff. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Security hardening
+- [ ] Documentation
+- [ ] Refactor / chore
+
+## Checklist
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm run build` succeeds
+- [ ] Scoped to a single concern
+- [ ] No secrets, keys, or `.env` files committed
+- [ ] User-facing strings are clear and calm
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug: elm.chat (Chrome)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/apps/web",
+      "preLaunchTask": "dev:servers",
+      "sourceMaps": true
+    },
+    {
+      "name": "Debug: elm.chat (Edge)",
+      "type": "msedge",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/apps/web",
+      "preLaunchTask": "dev:servers",
+      "sourceMaps": true
+    }
+  ],
+  "compounds": []
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,76 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "dev:api",
+      "detail": "Cloudflare Worker + Durable Object (wrangler dev on :8787)",
+      "type": "shell",
+      "command": "npm run dev:api",
+      "isBackground": true,
+      "presentation": {
+        "group": "elm-chat-dev",
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "problemMatcher": {
+        "owner": "wrangler",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "file": 1,
+          "location": 1,
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*(Starting local server|wrangler).*",
+          "endsPattern": ".*Ready on http.*"
+        }
+      }
+    },
+    {
+      "label": "dev:web",
+      "detail": "Vite dev server with HMR (:3000, proxies /api to the Worker)",
+      "type": "shell",
+      "command": "npm run dev:web",
+      "isBackground": true,
+      "presentation": {
+        "group": "elm-chat-dev",
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "file": 1,
+          "location": 1,
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*(VITE|vite).*",
+          "endsPattern": ".*Local:.*http.*"
+        }
+      }
+    },
+    {
+      "label": "dev:servers",
+      "detail": "Start both the Worker and the web dev server, then wait until both are ready.",
+      "dependsOn": ["dev:api", "dev:web"],
+      "dependsOrder": "parallel",
+      "problemMatcher": []
+    },
+    {
+      "label": "dev",
+      "detail": "Start the full stack and open elm.chat in your default browser (no debugger).",
+      "type": "shell",
+      "command": "open http://localhost:3000 || xdg-open http://localhost:3000 || start http://localhost:3000",
+      "dependsOn": ["dev:servers"],
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/AUTOMATION-PLAYBOOK.md
+++ b/AUTOMATION-PLAYBOOK.md
@@ -1,0 +1,81 @@
+# elm.chat — Automation Playbook
+
+*What I (your Cowork agent) can do for you directly, what needs one click from you, and what only you can do. Companion to `GROWTH-PLAN.md`.*
+
+The honest framing: I can do the **making, drafting, scheduling, and repo work** end-to-end. I can't *be* an account (post as you, sign up on your behalf, or click "publish" on external sites) unless you connect a tool or drive a browser session with me. So the model is: **I produce everything; you approve/click; recurring work runs on a schedule.** Here's the full map.
+
+---
+
+## Tier 1 — I can do this now, in the repo (just say go)
+
+These are code/content changes in your connected folder. I write them; you review the diff and push.
+
+1. **`LICENSE`** — add the license you choose (AGPL-3.0 or MIT). *Blocks your fork/contribute goal until it exists.*
+2. **Contributor on-ramp** — `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` (responsible-disclosure policy — important for a crypto tool), `.github/ISSUE_TEMPLATE/`, PR template.
+3. **"Good first issues"** — draft 8–12 well-scoped tickets from your README's "What We Need Help With" list, ready to paste into GitHub Issues.
+4. **Deploy to Cloudflare button** — add to README with the correct config so one click clones + provisions Durable Objects on a visitor's account (Loop 2).
+5. **README glow-up** — badges (license, stars, build), the demo GIF slot, tightened top-of-fold pitch.
+6. **Loop 1 invite-footer** — implement the "created with elm.chat — make your own" line on the invite/landing surface and the "room gone → start new" screen. (I'll write the code; it touches `apps/web`.)
+7. **Privacy-safe analytics** — wire in Cloudflare Web Analytics or Plausible (no cookies, on-brand).
+8. **SEO landing pages** — build the comparison/how-to pages (§Loop 3) as static routes with live "create a room" CTAs.
+9. **A one-page abuse/reporting policy** — needed before press (see Growth Plan §7).
+
+## Tier 2 — I draft it fully; you paste/publish (5-min click)
+
+External platforms I can't post to directly, but I'll hand you copy-paste-ready assets:
+
+10. **Show HN post** — title options (title is 80% of the outcome), body, and a pre-written comment answering the top 5 questions you'll get. Plus the ideal day/time.
+11. **Product Hunt kit** — tagline, description, first comment, gallery shot list, and the alt-platform versions (Peerlist, Uneed, etc.).
+12. **Reddit posts** — tailored, non-spammy versions for r/privacy, r/selfhosted, r/opensource, r/crypto, each leading with the right angle.
+13. **awesome-list PRs** — the exact entry text + which repos to PR (awesome-privacy, awesome-selfhosted, PrivacyGuides).
+14. **Blog post** — "How I built an E2E ephemeral chat on Cloudflare Durable Objects" (ranks well, recruits contributors). Full draft.
+15. **Launch-day runbook** — hour-by-hour checklist so the multi-channel launch is coordinated, not scattered.
+16. **Press pitch** — a tight email pitch + target list (404 Media, The Verge, TechCrunch, etc.) timed to the audit.
+
+## Tier 3 — Recurring, on autopilot (scheduled tasks I set up)
+
+I can create scheduled tasks that run without you. Candidates:
+
+17. **Weekly content engine** — every Monday I draft the week's SEO page + 3 short-form video scripts + a build-in-public thread, and drop them in a `growth/` folder for your approval.
+18. **Daily launch-window monitor** (launch week) — each morning I check your Show HN/PH threads and draft replies to new comments for you to post.
+19. **Weekly metrics digest** — I pull your analytics + GitHub stars/forks and email you a K-factor readout with "what to do next."
+20. **Competitor/mention watch** — weekly scan for new "self-destructing chat" search trends, competitor launches, and anyone mentioning elm.chat, so you can engage.
+
+*(These use the scheduling system. I'll wire up whichever you want.)*
+
+## Tier 4 — Needs you to connect a tool, then I run it
+
+21. **Actual social posting.** There's no social-posting connector in the registry today, so two options: **(a)** connect **Claude in Chrome** and I'll drive your browser to post to X/Bluesky/Reddit with your approval on each; or **(b)** I keep drafting + scheduling and you paste. I recommend (a) for X/Bluesky build-in-public cadence.
+22. **GitHub automation.** If you connect a GitHub tool, I can open the issues, apply labels, and manage the PR templates directly instead of handing you text.
+23. **Email outreach** (campus profs, digital-security orgs, press). If you connect Gmail, I draft + queue; you approve sends. Otherwise I hand you the drafts.
+
+## Tier 5 — Only you can do (I'll prep everything up to the click)
+
+- Choosing the license (legal decision — see below).
+- Final "publish" on Show HN / Product Hunt (their ToS require the human account holder).
+- `git push` to your repo and Cloudflare deploys (your credentials).
+- Any claim about security guarantees to at-risk users — human judgment call.
+- Recruiting/managing real campus ambassadors (relationships).
+
+---
+
+## The one decision blocking Tier 1: your license
+
+Your repo has **no LICENSE file**, which under default copyright law means *no one may legally fork, modify, or contribute* — directly contradicting your stated goal. Pick one and I'll add it immediately:
+
+- **AGPL-3.0** — anyone who runs a *modified public* instance must publish their changes. Best for a privacy/trust project: prevents a company from taking your code, running a secretly-weakened version, and keeping it closed. Slightly scares off corporate adopters.
+- **MIT** — do anything, just keep the copyright notice. Maximum adoption and forks; you lose the copyleft protection.
+- **MPL-2.0** — middle ground (file-level copyleft).
+
+For elm.chat specifically, **AGPL-3.0** aligns with "you should not have to trust infrastructure" — but it's your call.
+
+---
+
+## Suggested first move
+
+Fastest path to momentum, in order:
+1. You pick a license → I ship all of **Tier 1** (repo becomes forkable, self-hostable, launch-ready).
+2. I draft the full **Tier 2** launch kit.
+3. We set the launch date, I set up **Tier 3** schedules, and you connect **Claude in Chrome / GitHub** if you want me posting and filing issues directly.
+
+Tell me the license and which tier to start with, and I'll begin.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via the contact listed on the maintainer's GitHub profile. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to elm.chat
+
+Thank you for considering a contribution. elm.chat is an open effort to build genuinely private, ephemeral messaging with as little server trust as possible. High standards are welcome — this is security-sensitive software, and thoughtful scrutiny is a feature, not a nuisance.
+
+## Ways to contribute
+
+You don't have to write code to help:
+
+- **Cryptographic review** — audit the key exchange, message encryption, and secret handling. Challenge our assumptions.
+- **Protocol design** — transcript sync, deduplication, peer authentication, replay resistance.
+- **Threat modeling** — poke holes in `docs/threat-model.md`. Adversarial thinking is the point.
+- **Mobile-first UX** — the app should be usable under stress, on a phone, one-handed.
+- **Accessibility** — screen-reader support, keyboard nav, high-contrast, reduced motion.
+- **Documentation** — clarify, correct, and expand the docs.
+- **Bug reports** — file precise, reproducible issues.
+
+See [good first issues](docs/GOOD-FIRST-ISSUES.md) for scoped starting points.
+
+## Ground rules
+
+1. **Privacy is the product.** If a change improves convenience but expands retention, logging, observability, or recoverable history, it will be challenged hard. Justify any new data that touches the server.
+2. **No new telemetry on room contents.** Aggregate, content-free counters on public surfaces (landing/invite pages) are fine; anything that could deanonymize participants or reconstruct a transcript is not.
+3. **Small, reviewable PRs.** One concern per pull request. Large refactors should start as an issue for discussion.
+4. **Explain the security implications.** Every PR description should answer: does this change what the server can see, retain, or reconstruct?
+
+## Development setup
+
+Prerequisites: Node.js + npm, and a Cloudflare account only if you want to deploy.
+
+```bash
+git clone https://github.com/shawnbure/elm-chat.git
+cd elm-chat
+npm install
+npm run build   # once, creates apps/web/dist which wrangler dev expects
+npm run dev     # runs the Worker + Vite dev server together
+```
+
+Open `http://localhost:3000`, create a room, then open the invite link in a second tab to see live encrypted chat. See `README.md` for VS Code run/debug configs and Turnstile setup.
+
+## Pull request checklist
+
+- [ ] `npm run typecheck` passes.
+- [ ] `npm run build` succeeds.
+- [ ] The PR is scoped to a single concern.
+- [ ] The description states any change to what the server can see, log, or retain.
+- [ ] New user-facing strings are clear and calm (this app is often used under stress).
+- [ ] No secrets, keys, or `.env` files committed.
+
+## Reporting security issues
+
+**Do not open a public issue for a vulnerability.** Follow the process in [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's [GNU AGPL-3.0](LICENSE). This keeps every public deployment — including modified ones — open to its users, which is the whole point of a trust-minimizing tool.
+
+## Code of conduct
+
+Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Be rigorous with ideas and kind to people.

--- a/GROWTH-PLAN.md
+++ b/GROWTH-PLAN.md
@@ -1,0 +1,159 @@
+# elm.chat — Growth Plan: 0 → Millions
+
+*A strategy for turning an ephemeral messenger into a viral, forkable, contributor-driven project — built for a $0 budget and heavy automation.*
+
+---
+
+## 0. The one idea that makes everything else work
+
+Ephemeral messengers have the worst cold-start problem in software. A normal social network is at least a little useful with a few friends. An ephemeral, no-account, no-contacts, no-history messenger is useful **only** in the exact moment two people are in a room together — and by design it leaves no artifact behind to pull in the next user. You cannot win this by "getting people to switch from WhatsApp." That is a network-effects death march you will lose.
+
+**So don't play that game. Reframe the product.**
+
+elm.chat is not "a messenger you and your friends adopt." It is **a link you generate and hand to someone for a single, sensitive purpose.** That reframe is the whole strategy, because it changes the unit of growth from *a network* to *a link* — and a link is inherently viral, brings its own second user, and needs zero pre-existing audience.
+
+Think Calendly, Google Meet, typeform, PrivateBin, or a Google Doc share link: single-player-to-start, and every use spreads the tool to at least one new person who has to click it. That is your growth engine. **Every room invite is a distribution event.** Your job is to (a) maximize the number of reasons someone spins up a room, and (b) make sure the person receiving the invite learns they can make their own.
+
+Everything below builds on that reframe.
+
+---
+
+## 1. Positioning & the wedge use cases
+
+Lead with **single-session, single-purpose, "bring your own counterparty"** use cases. These need no network — the creator already knows who they're inviting.
+
+Highest-leverage wedges, in order:
+
+1. **One-time secret / credential handoff.** "Send me your password / API key / SSN / wallet seed — through a room that self-destructs." This competes with PrivateBin / Yopass / One-Time Secret, which get millions of hits, but you add *live back-and-forth* and *file transfer*. Huge, evergreen search demand.
+2. **Anonymous feedback & confessions.** A creator opens a room, drops the invite in a group chat / on a slide / in a bio, and collects candid input that vanishes. Perfect for classrooms, teams, communities.
+3. **Sensitive personal coordination.** Legal, medical, financial, breakup/divorce, HR complaints — conversations people specifically do *not* want archived. Your README already nails this audience.
+4. **Tip line / whistleblower intake.** An embeddable "Contact us securely" room a newsroom, NGO, or company posts publicly. One creator, many high-intent visitors.
+5. **Throwaway coordination for events/marketplaces.** Meeting a stranger from Craigslist/FB Marketplace, coordinating a protest, a one-off project — chat that dies when the thing is over.
+
+**Tagline candidates** (you already have a strong one on the landing page): keep *"Instant chat. Private, secure, fast and disposable."* For campaigns, sharpen to outcomes: *"A conversation that deletes itself."* / *"Chat that leaves no trace."* / *"Spin up a room. Say the thing. Let it vanish."*
+
+**Naming the category matters.** Own a phrase and repeat it everywhere: **"disposable rooms"** or **"self-destructing chat."** Categories are cheaper to win than brands.
+
+---
+
+## 2. The growth model (viral loops)
+
+You need loops, not campaigns. A campaign is a spike; a loop compounds. Build these three, in order of priority:
+
+### Loop 1 — The invite loop (product-led, highest priority)
+Every room works by the creator sharing an invite link. That link lands on a person who may have never heard of elm.chat. So:
+
+- The **invite landing page** (before someone joins) must carry a tasteful, non-creepy footer: *"This secure room was created with elm.chat — make your own free, no signup."* One line, one link. This is the single most important growth change you can ship. It costs nothing and turns every conversation into an ad.
+- After a room self-destructs, show a **"Room gone. Start a new one →"** screen. The moment of "that was clean and easy" is peak intent to reuse and share.
+- Optional, privacy-safe: a lightweight *"K+ rooms created this week"* counter (aggregate, no logging of content) for social proof.
+
+> Design constraint: none of this can compromise the privacy promise. It's UI on the *public* invite/landing surface, not telemetry on room contents. Keep it that way and the community will trust it.
+
+### Loop 2 — The fork/self-host loop (developer-led)
+Because elm.chat is Cloudflare-native, you can add a **"Deploy to Cloudflare" button** to the README. One click clones the repo into the visitor's own GitHub *and* auto-provisions their Durable Objects — they get their own running instance in ~60 seconds, free. ([Cloudflare docs](https://developers.cloudflare.com/workers/platform/deploy-buttons/)). This is rare and remarkable: most apps can't offer true one-click self-host. It converts "cool project" into "I'm running it," which drives stars, forks, blog posts, and word of mouth among exactly the people who evangelize privacy tools.
+
+### Loop 3 — The content/SEO loop (audience-led)
+Publish comparison and how-to pages that rank for the buying-intent searches your wedges create ("self-destructing chat," "send password securely," "Snapchat alternative that actually deletes," "anonymous feedback link"). Each page ends with a live "create a room now" CTA. Search traffic → room creation → invite loop. Compounds for years, costs only writing time (which I automate — see Part 2).
+
+---
+
+## 3. Phased roadmap: 0 → millions
+
+Don't chase "millions" directly. Win one tight community completely, then repeat. Cold-start is beaten by **density, not breadth** — 1,000 users who all know each other beat 100,000 scattered strangers.
+
+### Phase 0 — Make it launch-worthy (Week 1)
+Before any promotion, the repo and product must reward attention.
+- **Add a LICENSE** (you have none — this legally blocks forking/contributing, which are your stated goals). Recommend **AGPL-3.0** (forces anyone who runs a modified public instance to open their changes — ideal for a privacy tool where trust matters) or **MIT** (maximum adoption). *This is a decision only you can make; see Part 3.*
+- Add `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue/PR templates, and 8–12 well-scoped "good first issue" tickets. Contributors need an on-ramp.
+- Add the **Deploy to Cloudflare** button + a 60-second demo GIF at the top of the README.
+- Ship the **Loop 1** invite-footer change.
+- Set up privacy-respecting aggregate analytics (Cloudflare Web Analytics or Plausible — no cookies, on-brand).
+
+### Phase 1 — The launch spike (Weeks 2–3): 0 → ~1–5k
+Coordinated multi-channel launch. Order matters.
+- **Show HN** as the anchor (highest-value channel for open-source privacy tools — this is where your actual users and contributors are). Title matters enormously; post Tue–Thu morning US time; be present all day to answer.
+- Same week: **Product Hunt** + 2–3 alternatives (Peerlist, Uneed, etc. — multi-platform launches convert ~40% better than single).
+- Targeted subreddits: r/privacy, r/selfhosted, r/opensource, r/crypto, r/degoogle. Lead with the self-host/fork angle, not "use my app" (Reddit punishes promotion, rewards genuine builds).
+- Lobsters, the privacy tools ecosystem (PrivacyGuides forum, awesome-privacy / awesome-selfhosted PRs), and Mastodon/Bluesky privacy communities.
+- Have a **crash plan**: a good Show HN can flood a free-tier Worker. Test load first.
+
+### Phase 2 — Beachhead domination (Months 1–3): → ~50k
+Pick **one** community and go deep. Your three chosen audiences map to three plays; I recommend **sequencing** them rather than doing all at once:
+
+- **Privacy/infosec first** (fastest, warmest, lowest cost). They found you at launch. Convert them into contributors and self-hosters. Get a **cryptographic review** underway publicly (your README asks for one) — "we're being audited" is itself a story and a trust unlock. Ship an audit/threat-model page.
+- **Activists & journalists second** (highest mission-fit, but earn trust *before* pursuing — a half-reviewed tool marketed to at-risk users is dangerous, and your own README warns against this). Once review is underway, reach out to digital-security trainers (Access Now, Freedom of the Press Foundation, EFF's Surveillance Self-Defense community) — not to be endorsed, but to be evaluated and listed.
+- **College campuses third** (highest raw viral coefficient once the product is proven). See the campus playbook below.
+
+### Phase 3 — The campus flywheel (Months 3–9): → hundreds of thousands
+Campuses are the best cold-start environment on earth: dense, high-trust, novelty-hungry, and full of natural single-purpose use cases (anonymous course feedback, club coordination, confessions, dating-adjacent "slide into a disposable room," study-group cram sessions, dorm gossip that shouldn't be screenshot-able). One campus can hit critical density in weeks, and students carry it to the next campus. Playbook in §5.
+
+### Phase 4 — Broad + durable (Months 9+): → millions
+By now you have: an SEO moat (Loop 3 compounding), a self-hosting community (Loop 2), a proven campus motion to replicate, and press from the audit. Now broad paid or PR pushes actually convert because the loops catch and retain the traffic. This is when "millions" becomes an arithmetic problem, not a hope.
+
+---
+
+## 4. Channel playbook (all $0)
+
+| Channel | Play | Why it works here |
+|---|---|---|
+| **Show HN** | Anchor launch + resubmit on major features/audit results | Your users and contributors literally live here |
+| **Product Hunt + alts** | Coordinated launch day, multi-platform | Distribution + backlinks + social proof |
+| **Reddit** | Self-host/fork angle in r/privacy, r/selfhosted, r/opensource | High-intent, allergic to ads — so be a builder, not a marketer |
+| **awesome-* lists** | PRs to awesome-privacy, awesome-selfhosted, PrivacyTools | Evergreen referral traffic + credibility |
+| **SEO comparison pages** | "send password securely," "self-destructing chat," etc. | Compounding buying-intent traffic → Loop 1 |
+| **Short-form video** | 15–30s "spin up a room, it vanishes" demos on TikTok/Reels/Shorts | Ephemerality is visually satisfying; privacy is trending |
+| **X / Bluesky / Mastodon** | Build-in-public thread series; engage privacy voices | Cheap reach among evangelists |
+| **Dev.to / Hashnode / personal blog** | "How I built an E2E ephemeral chat on Cloudflare DOs" | Ranks well, attracts contributors, teaches the architecture |
+| **Campus ambassadors** | Student reps, flyers with QR to a room, club partnerships | Density engine (Phase 3) |
+| **Press** | Pitch the audit + the "chat that deletes itself" angle to TechCrunch/The Verge/404 Media | Earned, credible, drives a spike the loops can catch |
+
+---
+
+## 5. The campus playbook (your "college integration")
+
+The trick on campus is to lead with a **use case that needs no network**, then let density build:
+
+1. **Anonymous feedback / Q&A for professors and clubs.** Give a professor a room link to collect honest mid-semester feedback; give a club a room for anonymous suggestions. One creator, dozens of participants, zero friction, and every participant sees the "make your own" footer.
+2. **QR-code flyers** in dorms, dining halls, and event boards: *"Say the thing you can't say. Scan → anonymous room → gone in an hour."* QR → room → invite loop.
+3. **Ambassador program**: recruit 1–2 students per campus. Their job is to seed 5 use cases (a club, a class, a group chat). Reward with swag, GitHub-contributor cred, LinkedIn "Campus Lead" title, or leaderboard status — not cash (you have $0, and status motivates students well).
+4. **Event mode**: hackathons, protests, orientation week, finals — moments where disposable coordination is genuinely useful. Show up with the tool.
+5. **Replicate**: each ambassador who succeeds becomes a case study to recruit the next campus.
+
+---
+
+## 6. Metrics that matter (and the ones that don't)
+
+Because you can't (and shouldn't) track message content, measure the *public* funnel:
+- **Rooms created / week** (top-line health).
+- **Invite-link click-through** (are rooms actually reaching a second person? = Loop 1 strength).
+- **"Make your own" CTA clicks** on invite pages (viral conversion).
+- **GitHub stars / forks / self-host deploys** (Loop 2).
+- **SEO impressions & page → room-creation rate** (Loop 3).
+- **K-factor**: new creators generated per existing creator. Above 1.0 = viral. This is the number to obsess over.
+
+Vanity metrics to ignore: raw pageviews, social followers, "impressions." They don't feed a loop.
+
+---
+
+## 7. The hard truths / risks
+
+- **Abuse.** Anonymous ephemeral chat *will* attract bad actors. You already have Turnstile — good. Have a clear, public abuse policy and a takedown/reporting path *before* press, or the first negative story defines you. This is existential for the college motion specifically.
+- **Trust vs. hype.** Your README's own disclaimer is right: do not market to activists/journalists as a finished high-assurance tool before independent review. Sequence accordingly (Phase 2). Overclaiming security is the fastest way to lose the privacy community's trust permanently.
+- **Free-tier ceilings.** Cloudflare's free plan has limits; a viral spike could hit them. Know your ceiling and your upgrade path before launch day.
+- **Retention is not the goal — recurrence is.** People won't use elm.chat daily. Success is that they *remember it exists* the next time they need a private room. Brand recall > DAU. Optimize messaging for "the tool you reach for when it matters."
+
+---
+
+## 8. The 90-day critical path (summary)
+
+- **Week 1:** LICENSE + contributor files + Deploy button + invite-footer loop + analytics. *(Mostly automatable — Part 2.)*
+- **Week 2–3:** Coordinated Show HN / Product Hunt / Reddit launch. Ship 2–3 SEO pages.
+- **Month 1–2:** Convert infosec crowd → contributors + self-hosters. Kick off public crypto review. Publish 1–2 SEO pages/week.
+- **Month 2–3:** Line up digital-security orgs for evaluation. Recruit first 2–3 campus ambassadors.
+- **Month 3+:** Campus flywheel + audit-results press + double down on whichever loop shows K > 1.
+
+The north star: **get the invite loop's K-factor above 1.0.** Everything else is fuel for that fire.
+
+---
+
+*Companion doc: `AUTOMATION-PLAYBOOK.md` — exactly what can be run for you, and how.*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,665 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public
+License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds
+of works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users can
+regenerate automatically from other parts of the Corresponding Source.
+
+  The Corresponding Source for a work in source code form is that same
+work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these
+conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the Corresponding
+    Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for
+incorporation into a dwelling.  In determining whether a product is a
+consumer product, doubtful cases shall be resolved in favor of
+coverage.  For a particular product received by a particular user,
+"normally used" refers to a typical or common use of that class of
+product, regardless of the status of the particular user or of the way
+in which the particular user actually uses, or expects or is expected
+to use, the product.  A product is a consumer product regardless of
+whether the product has substantial commercial, industrial or
+non-consumer uses, unless such uses represent the only significant mode
+of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product
+from a modified version of its Corresponding Source.  The information
+must suffice to ensure that the continued functioning of the modified
+object code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders
+of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions; the
+above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not convey it at all.  For example, if you agree to terms that
+obligate you to collect a royalty for further conveying from those to
+whom you convey the Program, the only way you could satisfy both those
+terms and this License would be to refrain entirely from conveying the
+Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new
+versions will be similar in spirit to the present version, but may differ
+in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero
+General Public License "or any later version" applies to it, you have
+the option of following the terms and conditions either of that
+numbered version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number
+of the GNU Affero General Public License, you may choose any version
+ever published by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that
+proxy's public statement of acceptance of a version permanently
+authorizes you to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these
+terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -162,23 +162,24 @@ npm install
 # 2. Authenticate Wrangler (opens a browser)
 npx wrangler login
 
-# 3. Build the web app (creates apps/web/dist that the Worker serves)
-npm run build
+# 3. (If your Cloudflare login has more than one account) pick the target.
+#    This project-scoped variable maps to Wrangler's account for deploys,
+#    so it won't clobber CLOUDFLARE_ACCOUNT_ID for your other projects.
+export ELM_CHAT_CLOUDFLARE_ACCOUNT_ID=<your-account-id>
 
-# 4. Deploy the Worker + Durable Object
-cd workers/api
-npx wrangler deploy
+# 4. Build the web app and deploy the Worker + Durable Object (one command)
+npm run deploy
 ```
 
-On success, Wrangler prints your live URL, e.g. `https://elm-chat.<your-subdomain>.workers.dev`. Open it, click **Create private conversation**, and you have a working room.
+`npm run deploy` (run from the repo root) builds `apps/web/dist` and then deploys the Worker. On success, Wrangler prints your live URL, e.g. `https://elm-chat.<your-subdomain>.workers.dev`. Open it, click **Create private conversation**, and you have a working room.
 
 Notes:
 
-- **Choosing an account.** `wrangler.jsonc` intentionally does **not** hardcode an `account_id`, so it deploys to whatever account you logged in with. If your Wrangler login has access to more than one account, set the target explicitly: `export CLOUDFLARE_ACCOUNT_ID=<your-account-id>` (find it under **Workers & Pages → Account details** in the dashboard), or pass `--account <id>` to `wrangler deploy`.
-- **workers.dev subdomain.** The first time you deploy to an account, Cloudflare may ask you to register a free `*.workers.dev` subdomain (in the dashboard under **Workers & Pages**). Do that once, then re-run `wrangler deploy`.
+- **Choosing an account.** `wrangler.jsonc` intentionally does **not** hardcode an `account_id`, so it deploys to whatever account you logged in with. If your login has access to more than one account, set **`ELM_CHAT_CLOUDFLARE_ACCOUNT_ID`** (find the id under **Workers & Pages → Account details** in the dashboard). The `deploy` script maps it to the `CLOUDFLARE_ACCOUNT_ID` Wrangler expects, so it stays scoped to this project. If you already export the standard `CLOUDFLARE_ACCOUNT_ID`, that is used as a fallback.
+- **workers.dev subdomain.** The first time you deploy to an account, Cloudflare may ask you to register a free `*.workers.dev` subdomain (in the dashboard under **Workers & Pages**). Do that once, then re-run `npm run deploy`.
 - **Durable Object migration.** The `migrations` block in `wrangler.jsonc` creates the `RoomDurableObject` SQLite class automatically on first deploy — no manual step.
 - **Renaming.** To run multiple instances or avoid a name clash, change `"name"` in `workers/api/wrangler.jsonc` before deploying.
-- **Redeploying after changes.** Always run `npm run build` (from the repo root) before `wrangler deploy`, so the Worker ships the latest `apps/web/dist`.
+- **Redeploying after changes.** Just run `npm run deploy` again — it rebuilds `apps/web/dist` before deploying.
 
 ### Optional — custom domain
 
@@ -210,7 +211,7 @@ That matches the philosophy of the project anyway.
 ### Troubleshooting
 
 - **`Missing entry-point` / assets error on deploy** — you didn't build first. Run `npm run build` from the repo root, then `wrangler deploy` from `workers/api`.
-- **`More than one account available`** — set `CLOUDFLARE_ACCOUNT_ID` (see above).
+- **`More than one account available`** — set `ELM_CHAT_CLOUDFLARE_ACCOUNT_ID` (see above), then re-run `npm run deploy`.
 - **`workers.dev` URL returns 404 or won't register** — register your workers.dev subdomain in the dashboard, then redeploy.
 - **Room says "Room not found" right after creating it** — you're pointing the web app at a different Worker than the one that created the room (usually a stale local dev setup). In production this is one Worker, so it does not occur.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # elm.chat
 
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
+![Stars](https://img.shields.io/github/stars/shawnbure/elm-chat?style=social)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
+> **Instant chat. Private, secure, fast and disposable.** End-to-end encrypted rooms that self-destruct. No accounts, no archive, no trace.
+
 `elm.chat` is an open effort to build a messaging system for people who need privacy by default, operational simplicity, and as little server trust as possible.
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
+
+## Run your own in one click
+
+elm.chat is Cloudflare-native, so you can fork and self-host a full private instance in about a minute — Cloudflare clones the repo into your account and provisions the Durable Objects for you:
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
+
+Prefer to do it by hand? See [Free Cloudflare Setup](#free-cloudflare-setup) below. Want to contribute instead of just run it? Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the [good first issues](docs/GOOD-FIRST-ISSUES.md).
 
 ![elm.chat landing page](docs/images/landing-page.jpg)
 
@@ -71,9 +86,9 @@ The shipping implementation is built around:
 
 ### Why relay instead of peer-to-peer
 
-A WebRTC peer-to-peer scaffold exists in the codebase but is **intentionally disabled**. Relaying encrypted payloads through the Durable Object is a deliberate choice: it keeps every participant's IP address private from other room members (naive WebRTC would leak peer IPs via ICE), needs no TURN server, and works reliably on mobile and restrictive networks. The trade-off is that the honest-but-curious server relays ciphertext and can observe connection metadata (timing, sizes, presence). `stun.cloudflare.com` and the `/api/turn-credentials` endpoint are referenced only by the dormant WebRTC path and are not used by the shipping app.
+elm-chat does not use WebRTC peer-to-peer transport, and it contacts no STUN or TURN servers. Relaying encrypted payloads through the Durable Object is a deliberate choice: it keeps every participant's IP address private from other room members (naive WebRTC would leak peer IPs via ICE), needs no TURN server, and works reliably on mobile and restrictive networks. The trade-off is that the honest-but-curious server relays ciphertext and can observe connection metadata (timing, sizes, presence).
 
-The long-term direction still includes an optional direct-peer transport for participants who accept the IP-exposure trade-off, plus message authentication using the ephemeral identity keys already exchanged on join.
+The long-term direction may add an optional direct-peer transport for participants who accept the IP-exposure trade-off, plus message authentication using the ephemeral identity keys already exchanged on join.
 
 If you are contributing, treat the phrases "footprint-less", "log-less", and "no-server" as the product standard we are aiming toward, not as a slogan. See [docs/architecture.md](docs/architecture.md) and [docs/threat-model.md](docs/threat-model.md) for the precise current model.
 
@@ -299,6 +314,16 @@ Recommended reading in this repository:
 - [docs/room-lifecycle.md](docs/room-lifecycle.md)
 - [docs/why-use-elm-chat.md](docs/why-use-elm-chat.md)
 - [docs/truly-private-messaging.md](docs/truly-private-messaging.md)
+
+## License
+
+elm.chat is free software licensed under the **[GNU Affero General Public License v3.0](LICENSE)**. AGPL is chosen deliberately: because this is a trust-minimizing tool, anyone who runs a *modified public* instance must make their modified source available to that instance's users (see Section 13 of the license). That keeps every deployment — including forks — honest and inspectable, which is the entire point of a private messenger.
+
+If you deploy a modified version as a network service, you must offer its users access to the corresponding source. Contributions are accepted under the same license; see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Acceptable use
+
+Privacy protects people; it is not a shield for abuse. See [docs/abuse-policy.md](docs/abuse-policy.md) for what is not allowed, what the architecture does and does not let anyone see, and how to report a problem. Self-hosters are the operators of their own instances and are responsible for acceptable use and local-law compliance.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Inside a room, people see:
 - single-use invite links instead of a permanent reusable room invite
 - creator ability to revoke invites and remove participants
 - a single composer for fast message entry
-- encrypted file sharing that streams peer-to-peer over the relay and vanishes on the same policy as messages
+- encrypted file sharing that streams over the encrypted relay and vanishes on the same policy as messages
 - a room that is meant to disappear instead of becoming a permanent archive
 
 The interface is meant to feel immediate, readable, and disposable. It should communicate privacy without turning the user experience into a configuration maze.
@@ -58,24 +58,24 @@ This project is trying to move toward a system where:
 
 ## Current Direction
 
-The project is currently centered around:
+The shipping implementation is built around:
 
-- a Cloudflare Worker frontend and API layer
-- a Cloudflare Durable Object per room
-- encrypted room secrets kept in the URL fragment so they do not reach the server in normal requests
-- encrypted message payloads handled in the browser
-- creator-issued single-use invite links for room entry
-- a disposable room lifecycle instead of permanent conversation storage
+- a Cloudflare Worker serving the app and API, plus one Durable Object per room
+- room secrets kept in the URL fragment so they do not reach the server in normal requests
+- end-to-end encrypted message payloads (AES-GCM under a room key derived in the browser)
+- **encrypted content relayed — never stored — through the room's Durable Object over a single WebSocket**, so the server only ever sees ciphertext
+- end-to-end encrypted, chunked file sharing over that same relay
+- creator-issued single-use invite links, invite revocation, and participant removal
+- optional invisible Cloudflare Turnstile on room creation (inert until keys are configured)
+- a disposable room lifecycle (idle + max-age self-destruct, manual destroy) instead of permanent storage
 
-The long-term direction is stronger than the current implementation. The architectural target is:
+### Why relay instead of peer-to-peer
 
-1. socket-based live coordination for reliability
-2. client-aggregated transcript recovery
-3. no persistent server-side message archive
-4. peer-assisted synchronization when new participants join
-5. direct encrypted file exchange where practical
+A WebRTC peer-to-peer scaffold exists in the codebase but is **intentionally disabled**. Relaying encrypted payloads through the Durable Object is a deliberate choice: it keeps every participant's IP address private from other room members (naive WebRTC would leak peer IPs via ICE), needs no TURN server, and works reliably on mobile and restrictive networks. The trade-off is that the honest-but-curious server relays ciphertext and can observe connection metadata (timing, sizes, presence). `stun.cloudflare.com` and the `/api/turn-credentials` endpoint are referenced only by the dormant WebRTC path and are not used by the shipping app.
 
-If you are contributing, treat the phrases "footprint-less", "log-less", and "no-server" as the product standard we are aiming toward, not as a slogan.
+The long-term direction still includes an optional direct-peer transport for participants who accept the IP-exposure trade-off, plus message authentication using the ephemeral identity keys already exchanged on join.
+
+If you are contributing, treat the phrases "footprint-less", "log-less", and "no-server" as the product standard we are aiming toward, not as a slogan. See [docs/architecture.md](docs/architecture.md) and [docs/threat-model.md](docs/threat-model.md) for the precise current model.
 
 ## What This Is For
 
@@ -275,7 +275,8 @@ Priority contribution areas:
 - transcript sync and deduplication
 - mobile-first UX
 - accessibility under stress
-- secure file transfer
+- file-transfer hardening (large files, resumability, backpressure)
+- WebSocket auto-reconnect and resync
 - traffic and metadata minimization
 - operational hardening
 - documentation and threat modeling

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ elm.chat is Cloudflare-native, so you can fork and self-host a full private inst
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
 
-Prefer to do it by hand? See [Free Cloudflare Setup](#free-cloudflare-setup) below. Want to contribute instead of just run it? Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the [good first issues](docs/GOOD-FIRST-ISSUES.md).
+Prefer to do it by hand? See [Deploy to Cloudflare](#deploy-to-cloudflare) below. Want to contribute instead of just run it? Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the [good first issues](docs/GOOD-FIRST-ISSUES.md).
 
 ![elm.chat landing page](docs/images/landing-page.jpg)
 
@@ -130,34 +130,89 @@ Official references:
 - [Cloudflare Durable Objects pricing](https://developers.cloudflare.com/durable-objects/platform/pricing/)
 - [Cloudflare Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/)
 
-## Free Cloudflare Setup
+## Deploy to Cloudflare
 
-You can stand this project up on a free Cloudflare developer account.
+This is the complete, end-to-end guide to running your own elm.chat instance on Cloudflare. The whole app is a single Cloudflare Worker: it serves the static React app **and** the API, and coordinates each room with a Durable Object. There is no separate database, server, or STUN/TURN service to run.
 
-High-level setup:
+### What you need
 
-1. Create a Cloudflare account at [dash.cloudflare.com/sign-up](https://dash.cloudflare.com/sign-up).
-2. Install Node.js and npm.
-3. Install Wrangler:
-   `npm install -g wrangler`
-4. Authenticate Wrangler:
-   `wrangler login`
-5. Clone this repository.
-6. Install dependencies:
-   `npm install`
-7. Build the web app:
-   `npm run build`
-8. Deploy the Worker:
-   `cd workers/api && npx wrangler deploy`
+- A **Cloudflare account** (the free plan is enough) — [sign up](https://dash.cloudflare.com/sign-up).
+- **Node.js 18+** and npm.
+- **Git**.
 
-On free tier expectations:
+No paid add-ons are required. SQLite-backed Durable Objects (what this project uses) are available on the Workers Free plan.
+
+### Option A — one click
+
+1. Click **[Deploy to Cloudflare](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)**.
+2. Authorize Cloudflare to create a fork in your GitHub account and connect it to Workers Builds.
+3. When prompted for build settings, set the **build command** to `npm install && npm run build` and leave the Wrangler config path as `workers/api/wrangler.jsonc`. (The build step compiles the React app into `apps/web/dist`, which the Worker serves.)
+4. Deploy. Cloudflare provisions the Worker and the Durable Object namespace for you.
+
+If the hosted build fails for any reason, use Option B — it is the fully tested path.
+
+### Option B — manual deploy with Wrangler (recommended)
+
+```bash
+# 1. Clone and install
+git clone https://github.com/shawnbure/elm-chat.git
+cd elm-chat
+npm install
+
+# 2. Authenticate Wrangler (opens a browser)
+npx wrangler login
+
+# 3. Build the web app (creates apps/web/dist that the Worker serves)
+npm run build
+
+# 4. Deploy the Worker + Durable Object
+cd workers/api
+npx wrangler deploy
+```
+
+On success, Wrangler prints your live URL, e.g. `https://elm-chat.<your-subdomain>.workers.dev`. Open it, click **Create private conversation**, and you have a working room.
+
+Notes:
+
+- **Choosing an account.** `wrangler.jsonc` intentionally does **not** hardcode an `account_id`, so it deploys to whatever account you logged in with. If your Wrangler login has access to more than one account, set the target explicitly: `export CLOUDFLARE_ACCOUNT_ID=<your-account-id>` (find it under **Workers & Pages → Account details** in the dashboard), or pass `--account <id>` to `wrangler deploy`.
+- **workers.dev subdomain.** The first time you deploy to an account, Cloudflare may ask you to register a free `*.workers.dev` subdomain (in the dashboard under **Workers & Pages**). Do that once, then re-run `wrangler deploy`.
+- **Durable Object migration.** The `migrations` block in `wrangler.jsonc` creates the `RoomDurableObject` SQLite class automatically on first deploy — no manual step.
+- **Renaming.** To run multiple instances or avoid a name clash, change `"name"` in `workers/api/wrangler.jsonc` before deploying.
+- **Redeploying after changes.** Always run `npm run build` (from the repo root) before `wrangler deploy`, so the Worker ships the latest `apps/web/dist`.
+
+### Optional — custom domain
+
+To serve the app from your own domain instead of `*.workers.dev`:
+
+1. Add the domain to your Cloudflare account (it must use Cloudflare DNS).
+2. In the dashboard: **Workers & Pages → your Worker → Settings → Domains & Routes → Add custom domain**, or add a `routes` entry to `wrangler.jsonc` and redeploy. Cloudflare provisions the TLS certificate automatically.
+
+### Optional — abuse protection (Turnstile)
+
+Room creation can be gated by an invisible Cloudflare Turnstile challenge. It is off until you add keys, so the steps above work without it. See [Abuse Prevention (Turnstile)](#abuse-prevention-turnstile) below for the two-step setup.
+
+### Verify it works
+
+1. Open your deployed URL and create a room.
+2. Copy the room link (it contains a `#secret` fragment) and open it in a second browser or an incognito window to confirm two participants can exchange encrypted messages and files.
+3. Optional: watch live logs with `npx wrangler tail` from `workers/api`.
+
+### Free-tier expectations
 
 - keep rooms short-lived
 - keep storage minimal
-- expect usage ceilings
-- prefer aggressive cleanup and self-destruction policies
+- expect daily usage ceilings on the free plan
+- prefer aggressive message expiry and room self-destruct
+- large or frequent file transfers consume more of your Workers/Durable Object budget, since file chunks are relayed through the Worker
 
 That matches the philosophy of the project anyway.
+
+### Troubleshooting
+
+- **`Missing entry-point` / assets error on deploy** — you didn't build first. Run `npm run build` from the repo root, then `wrangler deploy` from `workers/api`.
+- **`More than one account available`** — set `CLOUDFLARE_ACCOUNT_ID` (see above).
+- **`workers.dev` URL returns 404 or won't register** — register your workers.dev subdomain in the dashboard, then redeploy.
+- **Room says "Room not found" right after creating it** — you're pointing the web app at a different Worker than the one that created the room (usually a stale local dev setup). In production this is one Worker, so it does not occur.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Inside a room, people see:
 - single-use invite links instead of a permanent reusable room invite
 - creator ability to revoke invites and remove participants
 - a single composer for fast message entry
+- encrypted file sharing that streams peer-to-peer over the relay and vanishes on the same policy as messages
 - a room that is meant to disappear instead of becoming a permanent archive
 
 The interface is meant to feel immediate, readable, and disposable. It should communicate privacy without turning the user experience into a configuration maze.
@@ -147,7 +148,7 @@ That matches the philosophy of the project anyway.
 
 The app runs as two processes in development:
 
-- the Cloudflare Worker + Durable Object under `wrangler dev` on `http://localhost:8787`
+- the Cloudflare Worker + Durable Object under `wrangler dev` on `http://localhost:8799` (a dedicated port set in `workers/api/wrangler.jsonc` so it never collides with other Cloudflare projects that default to `8787`)
 - the Vite dev server (React app, hot reload) on `http://localhost:3000`
 
 Vite proxies `/api` (including the room WebSocket) to the Worker, so the app behaves exactly like production, where a single Worker serves both the static assets and the API.
@@ -171,6 +172,21 @@ Two entry points are provided in `.vscode/`:
 
 - **Run without a debugger** — open the Command Palette → `Tasks: Run Task` → `dev` (also bound to the default build task, `Cmd/Ctrl+Shift+B`). This starts both servers and opens elm.chat in your **default browser**.
 - **Run with the debugger** — press `F5` and pick `Debug: elm.chat (Chrome)` or `Debug: elm.chat (Edge)`. This starts both servers and launches the chosen browser attached to the VS Code debugger, so breakpoints in the React/TypeScript source work. (VS Code's JavaScript debugger supports Chrome and Edge only; for other browsers use the no-debugger task above.)
+
+## Abuse Prevention (Turnstile)
+
+Room creation can be gated by [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/), a privacy-preserving bot check with no cookies, no cross-site tracking, and no persistent user identity. It is optional and stays off until you configure keys, so local dev and unconfigured deploys keep working.
+
+To enable it:
+
+1. In the Cloudflare dashboard, create a Turnstile widget (Managed or Invisible mode) for your domain. You get a **site key** (public) and a **secret key** (private).
+2. Give the web build the site key:
+   `VITE_TURNSTILE_SITE_KEY=<site-key> npm run build`
+   (or add it to a `.env` file under `apps/web`).
+3. Give the Worker the secret:
+   `cd workers/api && npx wrangler secret put TURNSTILE_SECRET`
+
+With both set, the landing page runs an invisible challenge before creating a room, and the Worker rejects room creation unless the token verifies. With neither set, creation is open.
 
 ## Durable Object Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,35 @@ On free tier expectations:
 
 That matches the philosophy of the project anyway.
 
+## Local Development
+
+The app runs as two processes in development:
+
+- the Cloudflare Worker + Durable Object under `wrangler dev` on `http://localhost:8787`
+- the Vite dev server (React app, hot reload) on `http://localhost:3000`
+
+Vite proxies `/api` (including the room WebSocket) to the Worker, so the app behaves exactly like production, where a single Worker serves both the static assets and the API.
+
+First-time setup:
+
+1. `npm install`
+2. `npm run build` once (creates `apps/web/dist`, which `wrangler dev` expects)
+
+Then, to run everything with one command:
+
+```
+npm run dev
+```
+
+Open `http://localhost:3000`. Create a room, then open the copied link (or an invite link) in a second browser/tab to see live encrypted chat between participants.
+
+### Running from VS Code
+
+Two entry points are provided in `.vscode/`:
+
+- **Run without a debugger** — open the Command Palette → `Tasks: Run Task` → `dev` (also bound to the default build task, `Cmd/Ctrl+Shift+B`). This starts both servers and opens elm.chat in your **default browser**.
+- **Run with the debugger** — press `F5` and pick `Debug: elm.chat (Chrome)` or `Debug: elm.chat (Edge)`. This starts both servers and launches the chosen browser attached to the VS Code debugger, so breakpoints in the React/TypeScript source work. (VS Code's JavaScript debugger supports Chrome and Edge only; for other browsers use the no-debugger task above.)
+
 ## Durable Object Lifecycle
 
 Each room is coordinated by a dedicated Durable Object instance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+elm.chat is privacy- and safety-critical software. We take vulnerabilities seriously and appreciate responsible disclosure.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report privately through one of:
+
+- GitHub's **[Private vulnerability reporting](https://github.com/shawnbure/elm-chat/security/advisories/new)** (preferred — go to the repo's Security tab → "Report a vulnerability").
+- Email the maintainer directly (see the GitHub profile for contact).
+
+Please include:
+
+- a description of the issue and its impact,
+- steps to reproduce (proof-of-concept if possible),
+- affected component(s) and version/commit,
+- any suggested mitigation.
+
+## What to expect
+
+- **Acknowledgement** within 72 hours.
+- An initial assessment and severity rating within 7 days.
+- Coordinated disclosure: we'll agree on a timeline and credit you (if you wish) in the advisory and release notes.
+
+## Scope
+
+In scope:
+
+- the encryption / key-exchange / secret-handling code (`packages/crypto`, room secret in URL fragment),
+- the Worker API and Durable Object room logic (metadata leakage, access control, invite handling),
+- the web client (XSS, secret exposure, storage of sensitive material),
+- anything that lets the server, an attacker, or a third party read, retain, or reconstruct message content or deanonymize participants.
+
+Out of scope (known and documented — see `docs/threat-model.md`):
+
+- compromise of a participant's own device (screenshots, clipboard, malware),
+- a participant voluntarily forwarding plaintext, screenshots, or the room secret,
+- transport-level metadata that is inherent to any networked system,
+- social engineering of participants.
+
+## A note on claims
+
+Per the project's own disclaimer: elm.chat should **not** be marketed or relied upon as a completed high-assurance safety tool until its protocol, implementation, and operational guarantees have been independently reviewed under realistic threat conditions. Security reports that move us toward that bar are exactly what we want.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,6 @@ import {
 } from "@elm-chat/crypto";
 import {
   DEFAULT_STUN_ICE_SERVERS,
-  DEFAULT_DISAPPEAR_AFTER_READ_SECONDS,
   MAX_TRANSCRIPT_SYNC_MESSAGES,
   type CreateRoomRequest,
   type CreateRoomResponse,
@@ -1170,7 +1169,7 @@ function RoomPage({ roomId }: { roomId: string }) {
       ciphertext: encrypted.ciphertext,
       nonce: encrypted.nonce,
       sentAt,
-      expiresAfterReadSeconds: room.disappearAfterReadSeconds ?? DEFAULT_DISAPPEAR_AFTER_READ_SECONDS
+      expiresAfterReadSeconds: room.disappearAfterReadSeconds ?? null
     };
 
     messageRef.current.set(envelope.messageId, envelope);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,7 +11,6 @@ import {
   generateSessionId
 } from "@elm-chat/crypto";
 import {
-  DEFAULT_STUN_ICE_SERVERS,
   FILE_CHUNK_BYTES,
   MAX_FILE_BYTES,
   MAX_TRANSCRIPT_SYNC_MESSAGES,
@@ -19,9 +18,7 @@ import {
   type CreateRoomResponse,
   type EncryptedMessageEnvelope,
   type PeerDataEvent,
-  type PeerDescriptor,
   type PeerFileChunk,
-  type PeerSignal,
   type PresenceSnapshot,
   type RoomInvite,
   type RoomMetadata,
@@ -68,11 +65,6 @@ type IncomingFile = {
   received: number;
   chunks: (Uint8Array | undefined)[];
   senderSessionId: string;
-};
-
-type PeerLink = {
-  peer: PeerDescriptor;
-  pc: RTCPeerConnection;
 };
 
 type ActionFeedback = "idle" | "success";
@@ -492,6 +484,20 @@ function roomStateMessage(status: RoomMetadata["status"], reason?: string): stri
   }
 }
 
+// Privacy-safe growth callout: shown on the end-of-room screens a link
+// recipient reaches. No tracking, no telemetry — just a way for a first-time
+// visitor to learn they can spin up their own room. elm.chat's main organic loop.
+function MakeYourOwnCallout() {
+  return (
+    <p className="make-your-own">
+      This secure room was made with elm.chat.{" "}
+      <a className="make-your-own-link" href="/">
+        Create your own &mdash; free, no signup.
+      </a>
+    </p>
+  );
+}
+
 function InvalidInviteScreen() {
   return (
     <main className="room-shell room-shell-centered">
@@ -504,6 +510,7 @@ function InvalidInviteScreen() {
         <a className="secondary-button access-home-link" href="/">
           Back to home
         </a>
+        <MakeYourOwnCallout />
       </section>
     </main>
   );
@@ -519,6 +526,7 @@ function RemovedFromRoomScreen() {
         <a className="secondary-button access-home-link" href="/">
           Back to home
         </a>
+        <MakeYourOwnCallout />
       </section>
     </main>
   );
@@ -832,7 +840,6 @@ function RoomPage({ roomId }: { roomId: string }) {
   // already-closed room without reading a stale `room` value.
   const roomStatusRef = useRef<RoomMetadata["status"] | null>(null);
   const chatLogRef = useRef<HTMLElement | null>(null);
-  const peersRef = useRef(new Map<string, PeerLink>());
   const messageRef = useRef(new Map<string, EncryptedMessageEnvelope>());
   const shouldRequestSyncRef = useRef(false);
   // Files being served by this client (we are the sender), kept in memory so we
@@ -843,7 +850,6 @@ function RoomPage({ roomId }: { roomId: string }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Object URLs created for received files, revoked on expiry/unmount.
   const objectUrlsRef = useRef(new Set<string>());
-  const peerTransportEnabled = false;
 
   function sendPeerData(payload: PeerDataEvent, toSessionId?: string) {
     const socket = socketRef.current;
@@ -1095,7 +1101,6 @@ function RoomPage({ roomId }: { roomId: string }) {
             return;
           }
           setConnection(roomStatusRef.current === "open" ? "Disconnected" : "Closed");
-          closeAllPeerLinks();
         });
 
         socket.addEventListener("error", () => {
@@ -1174,18 +1179,6 @@ function RoomPage({ roomId }: { roomId: string }) {
             if (creatorToken) {
               void refreshInvites();
             }
-            const link = peersRef.current.get(payload.sessionId);
-            if (link) {
-              link.pc.close();
-              peersRef.current.delete(payload.sessionId);
-            }
-            return;
-          }
-
-          if (payload.type === "signal") {
-            if (peerTransportEnabled) {
-              await handleIncomingSignal(payload.fromSessionId, payload.signal);
-            }
             return;
           }
 
@@ -1210,7 +1203,6 @@ function RoomPage({ roomId }: { roomId: string }) {
               setConnection("Closed");
             });
             sendPeerData({ type: "peer_destroy" });
-            closeAllPeerLinks();
             return;
           }
 
@@ -1248,113 +1240,6 @@ function RoomPage({ roomId }: { roomId: string }) {
       } catch (cause) {
         setError(cause instanceof Error ? cause.message : "Failed to join room.");
       }
-    }
-
-    function closeAllPeerLinks() {
-      for (const link of peersRef.current.values()) {
-        link.pc.close();
-      }
-      peersRef.current.clear();
-    }
-
-    function ensurePeer(peer: PeerDescriptor, initiator: boolean): PeerLink {
-      const existing = peersRef.current.get(peer.sessionId);
-      if (existing) {
-        return existing;
-      }
-
-      const pc = new RTCPeerConnection({ iceServers: DEFAULT_STUN_ICE_SERVERS });
-      const link: PeerLink = {
-        pc,
-        peer
-      };
-      peersRef.current.set(peer.sessionId, link);
-
-      pc.onicecandidate = (event) => {
-        if (!event.candidate) {
-          return;
-        }
-        socketRef.current?.send(
-          JSON.stringify({
-            type: "signal",
-            toSessionId: peer.sessionId,
-            signal: {
-              type: "ice",
-              candidate: event.candidate.candidate,
-              sdpMid: event.candidate.sdpMid,
-              sdpMLineIndex: event.candidate.sdpMLineIndex
-            }
-          })
-        );
-      };
-
-      pc.onconnectionstatechange = () => {
-        if (["failed", "closed", "disconnected"].includes(pc.connectionState)) {
-          const stale = peersRef.current.get(peer.sessionId);
-          if (stale?.pc === pc) {
-            peersRef.current.delete(peer.sessionId);
-          }
-        }
-      };
-
-      if (initiator) {
-        void (async () => {
-          const offer = await pc.createOffer();
-          await pc.setLocalDescription(offer);
-          socketRef.current?.send(
-            JSON.stringify({
-              type: "signal",
-              toSessionId: peer.sessionId,
-              signal: {
-                type: "offer",
-                sdp: offer.sdp ?? ""
-              }
-            })
-          );
-        })();
-      }
-
-      return link;
-    }
-
-    async function handleIncomingSignal(fromSessionId: string, signal: PeerSignal) {
-      const knownPeer =
-        peersRef.current.get(fromSessionId)?.peer ??
-        ({
-          sessionId: fromSessionId,
-          creator: false,
-          connectedAt: Date.now(),
-          identityKey: ""
-        } satisfies PeerDescriptor);
-      const link = ensurePeer(knownPeer, false);
-
-      if (signal.type === "offer") {
-        await link.pc.setRemoteDescription({ type: "offer", sdp: signal.sdp });
-        const answer = await link.pc.createAnswer();
-        await link.pc.setLocalDescription(answer);
-        socketRef.current?.send(
-          JSON.stringify({
-            type: "signal",
-            toSessionId: fromSessionId,
-            signal: {
-              type: "answer",
-              sdp: answer.sdp ?? ""
-            }
-          })
-        );
-        return;
-      }
-
-      if (signal.type === "answer") {
-        await link.pc.setRemoteDescription({ type: "answer", sdp: signal.sdp });
-        return;
-      }
-
-      await link.pc.addIceCandidate({
-        candidate: signal.candidate,
-        sdpMid: signal.sdpMid ?? null,
-        sdpMLineIndex: signal.sdpMLineIndex ?? null
-      });
     }
 
     async function addEnvelope(envelope: EncryptedMessageEnvelope) {
@@ -1482,7 +1367,6 @@ function RoomPage({ roomId }: { roomId: string }) {
       if (payload.type === "peer_destroy") {
         setRoomNotice("A connected peer destroyed this room.");
         setConnection("Closed");
-        closeAllPeerLinks();
       }
     }
 
@@ -1491,7 +1375,6 @@ function RoomPage({ roomId }: { roomId: string }) {
     return () => {
       active = false;
       window.clearInterval(tick);
-      closeAllPeerLinks();
       socketRef.current?.close();
     };
   }, [creatorToken, inviteToken, roomId, roomSecret, sessionId]);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,9 @@
 import {
   createIdentityKeyPair,
+  decryptBytes,
   decryptText,
   deriveRoomKey,
+  encryptBytes,
   encryptText,
   exportIdentityPublicKey,
   generateMessageId,
@@ -10,12 +12,15 @@ import {
 } from "@elm-chat/crypto";
 import {
   DEFAULT_STUN_ICE_SERVERS,
+  FILE_CHUNK_BYTES,
+  MAX_FILE_BYTES,
   MAX_TRANSCRIPT_SYNC_MESSAGES,
   type CreateRoomRequest,
   type CreateRoomResponse,
   type EncryptedMessageEnvelope,
   type PeerDataEvent,
   type PeerDescriptor,
+  type PeerFileChunk,
   type PeerSignal,
   type PresenceSnapshot,
   type RoomInvite,
@@ -26,12 +31,43 @@ import { startTransition, useEffect, useRef, useState, type CSSProperties } from
 
 type View = "landing" | "room";
 
+type FileTransferState =
+  | "offered"
+  | "requesting"
+  | "transferring"
+  | "ready"
+  | "sent"
+  | "error";
+
+type UiFile = {
+  fileId: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  state: FileTransferState;
+  progress: number;
+  url?: string;
+  outgoing: boolean;
+};
+
 type UiMessage = {
   id: string;
   senderSessionId: string;
-  plaintext: string;
   sentAt: number;
   expiresAt?: number;
+  kind: "text" | "file";
+  plaintext?: string;
+  file?: UiFile;
+};
+
+type IncomingFile = {
+  name: string;
+  mimeType: string;
+  size: number;
+  totalChunks: number;
+  received: number;
+  chunks: (Uint8Array | undefined)[];
+  senderSessionId: string;
 };
 
 type PeerLink = {
@@ -99,6 +135,20 @@ function formatStaticDuration(totalSeconds: number): string {
   }
 
   return parts.join(" ");
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
 }
 
 function creatorTokenKey(roomId: string): string {
@@ -200,6 +250,85 @@ function toggleIndefiniteDuration(
   };
 }
 
+let turnstileScriptPromise: Promise<void> | null = null;
+let turnstileWidgetId: string | undefined;
+let turnstilePendingResolve: ((token: string | undefined) => void) | null = null;
+
+function resolveTurnstile(token: string | undefined): void {
+  const resolve = turnstilePendingResolve;
+  turnstilePendingResolve = null;
+  resolve?.(token);
+}
+
+function loadTurnstileScript(): Promise<void> {
+  if (window.turnstile) {
+    return Promise.resolve();
+  }
+  if (!turnstileScriptPromise) {
+    turnstileScriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+      script.async = true;
+      script.defer = true;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error("challenge script failed to load"));
+      document.head.appendChild(script);
+    });
+  }
+  return turnstileScriptPromise;
+}
+
+// Runs an invisible Turnstile challenge when a site key is configured. Returns
+// the token, or undefined when Turnstile is not configured (local dev) or the
+// challenge could not run — the server decides whether a token is required.
+async function getTurnstileToken(): Promise<string | undefined> {
+  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+  if (!siteKey) {
+    return undefined;
+  }
+  try {
+    await loadTurnstileScript();
+  } catch {
+    return undefined;
+  }
+  const turnstile = window.turnstile;
+  if (!turnstile) {
+    return undefined;
+  }
+  return new Promise<string | undefined>((resolve) => {
+    turnstilePendingResolve = resolve;
+    let container = document.getElementById("turnstile-holder");
+    if (!container) {
+      container = document.createElement("div");
+      container.id = "turnstile-holder";
+      container.style.position = "fixed";
+      container.style.bottom = "-9999px";
+      container.style.left = "-9999px";
+      document.body.appendChild(container);
+    }
+    try {
+      if (turnstileWidgetId === undefined) {
+        turnstileWidgetId = turnstile.render(container, {
+          sitekey: siteKey,
+          execution: "execute",
+          appearance: "interaction-only",
+          callback: (token: string) => resolveTurnstile(token),
+          "error-callback": () => resolveTurnstile(undefined),
+          "timeout-callback": () => resolveTurnstile(undefined),
+          "expired-callback": () => resolveTurnstile(undefined)
+        });
+      } else {
+        turnstile.reset(turnstileWidgetId);
+      }
+      turnstile.execute(turnstileWidgetId, { sitekey: siteKey });
+    } catch {
+      resolveTurnstile(undefined);
+    }
+    // Never let a stuck challenge block room creation indefinitely.
+    window.setTimeout(() => resolveTurnstile(undefined), 8000);
+  });
+}
+
 async function createRoom(body: CreateRoomRequest): Promise<CreateRoomResponse> {
   const response = await fetch("/api/rooms", {
     method: "POST",
@@ -209,7 +338,8 @@ async function createRoom(body: CreateRoomRequest): Promise<CreateRoomResponse> 
     body: JSON.stringify(body)
   });
   if (!response.ok) {
-    throw new Error("Failed to create room.");
+    const detail = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(detail?.error ?? "Failed to create room.");
   }
   return response.json();
 }
@@ -394,6 +524,43 @@ function RemovedFromRoomScreen() {
   );
 }
 
+function FileCard({ file, onDownload }: { file: UiFile; onDownload: () => void }) {
+  const percent = Math.round((file.progress ?? 0) * 100);
+  return (
+    <div className="file-card">
+      <div className="file-card-head">
+        <span className="file-icon" aria-hidden="true">
+          &#128206;
+        </span>
+        <div className="file-meta">
+          <span className="file-name">{file.name}</span>
+          <span className="file-size">{formatBytes(file.size)}</span>
+        </div>
+      </div>
+      {file.outgoing ? (
+        <span className="file-status">Shared &mdash; peers can download</span>
+      ) : file.state === "offered" ? (
+        <button className="secondary-button file-action" onClick={onDownload} type="button">
+          Download
+        </button>
+      ) : file.state === "requesting" || file.state === "transferring" ? (
+        <div className="file-progress">
+          <div className="file-progress-track">
+            <div className="file-progress-bar" style={{ width: `${percent}%` }} />
+          </div>
+          <span className="file-progress-label">{percent}%</span>
+        </div>
+      ) : file.state === "ready" && file.url ? (
+        <a className="secondary-button file-action" download={file.name} href={file.url}>
+          Save file
+        </a>
+      ) : file.state === "error" ? (
+        <span className="file-status file-status-error">Transfer failed &mdash; ask for a re-share</span>
+      ) : null}
+    </div>
+  );
+}
+
 function InviteCheckingScreen() {
   return (
     <main className="room-shell room-shell-centered">
@@ -446,6 +613,7 @@ function LandingPage() {
       setCreating(true);
       setError(null);
       const secret = generateRoomSecret();
+      const turnstileToken = await getTurnstileToken();
       const room = await createRoom({
         disappearAfterReadSeconds: parseDurationDraft(
           messageDuration,
@@ -454,7 +622,8 @@ function LandingPage() {
           "seconds"
         ),
         inactivityTimeoutMs: parseDurationDraft(roomDuration, 10, "minutes", "milliseconds"),
-        maxAgeMs: null
+        maxAgeMs: null,
+        turnstileToken
       });
       safeStorageSet("local", creatorTokenKey(room.roomId), room.creatorToken);
       window.location.assign(`${room.roomUrl}#${secret}`);
@@ -658,16 +827,28 @@ function RoomPage({ roomId }: { roomId: string }) {
   const roomKeyRef = useRef<CryptoKey | null>(null);
   const identityKeyRef = useRef<string>("");
   const joinedRef = useRef(false);
+  // Mirror of the latest room status so the socket close handler (captured once
+  // by the connection effect) can distinguish a live-room drop from an
+  // already-closed room without reading a stale `room` value.
+  const roomStatusRef = useRef<RoomMetadata["status"] | null>(null);
   const chatLogRef = useRef<HTMLElement | null>(null);
   const peersRef = useRef(new Map<string, PeerLink>());
   const messageRef = useRef(new Map<string, EncryptedMessageEnvelope>());
   const shouldRequestSyncRef = useRef(false);
+  // Files being served by this client (we are the sender), kept in memory so we
+  // can stream chunks on demand when a peer requests them.
+  const outgoingFilesRef = useRef(new Map<string, File>());
+  // Files being received by this client, accumulating decrypted chunks.
+  const incomingFilesRef = useRef(new Map<string, IncomingFile>());
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Object URLs created for received files, revoked on expiry/unmount.
+  const objectUrlsRef = useRef(new Set<string>());
   const peerTransportEnabled = false;
 
-  function sendPeerData(payload: PeerDataEvent) {
+  function sendPeerData(payload: PeerDataEvent, toSessionId?: string) {
     const socket = socketRef.current;
     if (socket?.readyState === WebSocket.OPEN && joinedRef.current) {
-      socket.send(JSON.stringify({ type: "peer_data", data: payload }));
+      socket.send(JSON.stringify({ type: "peer_data", toSessionId, data: payload }));
       return true;
     }
     return false;
@@ -682,6 +863,178 @@ function RoomPage({ roomId }: { roomId: string }) {
       setInvites(nextInvites);
     } catch {
       // Keep the last known invite state if the refresh fails.
+    }
+  }
+
+  function updateFileMessage(fileId: string, patch: Partial<UiFile>) {
+    startTransition(() => {
+      setMessages((current) =>
+        current.map((message) =>
+          message.kind === "file" && message.file?.fileId === fileId
+            ? { ...message, file: { ...message.file, ...patch } }
+            : message
+        )
+      );
+    });
+  }
+
+  async function waitForSocketDrain() {
+    const socket = socketRef.current;
+    if (!socket) {
+      return;
+    }
+    const maxBuffer = 4 * 1024 * 1024;
+    while (socket.bufferedAmount > maxBuffer && socket.readyState === WebSocket.OPEN) {
+      await new Promise((resolve) => window.setTimeout(resolve, 25));
+    }
+  }
+
+  // Sender side: stream an outgoing file to the requesting peer as encrypted chunks.
+  async function serveFile(fileId: string, requesterSessionId: string) {
+    const file = outgoingFilesRef.current.get(fileId);
+    const key = roomKeyRef.current;
+    if (!file || !key) {
+      return;
+    }
+    const buffer = new Uint8Array(await file.arrayBuffer());
+    const totalChunks = Math.max(1, Math.ceil(buffer.byteLength / FILE_CHUNK_BYTES));
+    for (let index = 0; index < totalChunks; index += 1) {
+      const start = index * FILE_CHUNK_BYTES;
+      const slice = buffer.subarray(start, Math.min(start + FILE_CHUNK_BYTES, buffer.byteLength));
+      const { ciphertext, nonce } = await encryptBytes(key, slice);
+      await waitForSocketDrain();
+      const delivered = sendPeerData(
+        { type: "file_chunk", fileId, chunkIndex: index, totalChunks, ciphertext, nonce },
+        requesterSessionId
+      );
+      if (!delivered) {
+        return;
+      }
+    }
+    sendPeerData({ type: "file_complete", fileId }, requesterSessionId);
+  }
+
+  // Receiver side: decrypt and store an incoming chunk, updating transfer progress.
+  async function receiveChunk(payload: PeerFileChunk) {
+    const key = roomKeyRef.current;
+    if (!key) {
+      return;
+    }
+    let entry = incomingFilesRef.current.get(payload.fileId);
+    if (!entry) {
+      entry = {
+        name: "file",
+        mimeType: "application/octet-stream",
+        size: 0,
+        totalChunks: payload.totalChunks,
+        received: 0,
+        chunks: [],
+        senderSessionId: ""
+      };
+      incomingFilesRef.current.set(payload.fileId, entry);
+    }
+    if (entry.chunks.length !== payload.totalChunks) {
+      entry.chunks = new Array<Uint8Array | undefined>(payload.totalChunks);
+      entry.received = 0;
+      entry.totalChunks = payload.totalChunks;
+    }
+    if (!entry.chunks[payload.chunkIndex]) {
+      try {
+        entry.chunks[payload.chunkIndex] = await decryptBytes(key, payload.ciphertext, payload.nonce);
+        entry.received += 1;
+      } catch {
+        updateFileMessage(payload.fileId, { state: "error" });
+        return;
+      }
+    }
+    updateFileMessage(payload.fileId, {
+      state: "transferring",
+      progress: entry.totalChunks ? entry.received / entry.totalChunks : 0
+    });
+  }
+
+  // Receiver side: reassemble a completed file into a downloadable blob URL.
+  function finalizeIncoming(fileId: string) {
+    const entry = incomingFilesRef.current.get(fileId);
+    if (!entry) {
+      return;
+    }
+    if (entry.totalChunks === 0 || entry.received < entry.totalChunks) {
+      updateFileMessage(fileId, { state: "error" });
+      return;
+    }
+    const parts = entry.chunks.filter((chunk): chunk is Uint8Array => Boolean(chunk));
+    const blob = new Blob(parts as BlobPart[], { type: entry.mimeType });
+    const url = URL.createObjectURL(blob);
+    objectUrlsRef.current.add(url);
+    incomingFilesRef.current.delete(fileId);
+    updateFileMessage(fileId, { state: "ready", progress: 1, url });
+  }
+
+  async function handleAttachFiles(fileList: FileList | null) {
+    if (!fileList || !room || room.status !== "open") {
+      return;
+    }
+    for (const file of Array.from(fileList)) {
+      if (file.size > MAX_FILE_BYTES) {
+        setError(`"${file.name}" is larger than the ${formatBytes(MAX_FILE_BYTES)} limit.`);
+        continue;
+      }
+      const fileId = generateMessageId();
+      const sentAt = Date.now();
+      const mimeType = file.type || "application/octet-stream";
+      const expiresAfterReadSeconds = room.disappearAfterReadSeconds ?? null;
+      const expiresAt =
+        typeof expiresAfterReadSeconds === "number"
+          ? sentAt + expiresAfterReadSeconds * 1000
+          : undefined;
+      outgoingFilesRef.current.set(fileId, file);
+      setError(null);
+      startTransition(() => {
+        setMessages((current) =>
+          upsertMessage(current, {
+            id: fileId,
+            senderSessionId: sessionId,
+            sentAt,
+            expiresAt,
+            kind: "file",
+            file: {
+              fileId,
+              name: file.name,
+              mimeType,
+              size: file.size,
+              state: "sent",
+              progress: 1,
+              outgoing: true
+            }
+          })
+        );
+      });
+      const delivered = sendPeerData({
+        type: "file_offer",
+        fileId,
+        senderSessionId: sessionId,
+        name: file.name,
+        mimeType,
+        size: file.size,
+        sentAt,
+        expiresAfterReadSeconds
+      });
+      if (!delivered) {
+        setError("File shared locally, but delivery to other participants is not ready yet.");
+      }
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  function handleRequestFile(fileId: string, senderSessionId: string) {
+    updateFileMessage(fileId, { state: "transferring", progress: 0 });
+    const requested = sendPeerData({ type: "file_request", fileId }, senderSessionId);
+    if (!requested) {
+      updateFileMessage(fileId, { state: "error" });
+      setError("Could not reach the sender to start the download.");
     }
   }
 
@@ -741,7 +1094,7 @@ function RoomPage({ roomId }: { roomId: string }) {
             setReady(true);
             return;
           }
-          setConnection((current) => (room?.status === "open" ? "Disconnected" : "Closed"));
+          setConnection(roomStatusRef.current === "open" ? "Disconnected" : "Closed");
           closeAllPeerLinks();
         });
 
@@ -1032,7 +1385,8 @@ function RoomPage({ roomId }: { roomId: string }) {
               senderSessionId: envelope.senderSessionId,
               plaintext,
               sentAt: envelope.sentAt,
-              expiresAt
+              expiresAt,
+              kind: "text"
             })
           );
         });
@@ -1067,6 +1421,61 @@ function RoomPage({ roomId }: { roomId: string }) {
         for (const envelope of payload.messages) {
           await addEnvelope(envelope);
         }
+        return;
+      }
+
+      if (payload.type === "file_offer") {
+        const expiresAt =
+          typeof payload.expiresAfterReadSeconds === "number"
+            ? payload.sentAt + payload.expiresAfterReadSeconds * 1000
+            : undefined;
+        if (typeof expiresAt === "number" && expiresAt <= Date.now()) {
+          return;
+        }
+        incomingFilesRef.current.set(payload.fileId, {
+          name: payload.name,
+          mimeType: payload.mimeType || "application/octet-stream",
+          size: payload.size,
+          totalChunks: 0,
+          received: 0,
+          chunks: [],
+          senderSessionId: payload.senderSessionId
+        });
+        startTransition(() => {
+          setMessages((current) =>
+            upsertMessage(current, {
+              id: payload.fileId,
+              senderSessionId: payload.senderSessionId,
+              sentAt: payload.sentAt,
+              expiresAt,
+              kind: "file",
+              file: {
+                fileId: payload.fileId,
+                name: payload.name,
+                mimeType: payload.mimeType || "application/octet-stream",
+                size: payload.size,
+                state: "offered",
+                progress: 0,
+                outgoing: false
+              }
+            })
+          );
+        });
+        return;
+      }
+
+      if (payload.type === "file_request") {
+        void serveFile(payload.fileId, peerId);
+        return;
+      }
+
+      if (payload.type === "file_chunk") {
+        await receiveChunk(payload);
+        return;
+      }
+
+      if (payload.type === "file_complete") {
+        finalizeIncoming(payload.fileId);
         return;
       }
 
@@ -1133,7 +1542,20 @@ function RoomPage({ roomId }: { roomId: string }) {
 
   useEffect(() => {
     startTransition(() => {
-      setMessages((current) => current.filter((message) => !message.expiresAt || message.expiresAt > now));
+      setMessages((current) =>
+        current.filter((message) => {
+          const keep = !message.expiresAt || message.expiresAt > now;
+          if (!keep && message.kind === "file") {
+            if (message.file?.url) {
+              URL.revokeObjectURL(message.file.url);
+              objectUrlsRef.current.delete(message.file.url);
+            }
+            outgoingFilesRef.current.delete(message.id);
+            incomingFilesRef.current.delete(message.id);
+          }
+          return keep;
+        })
+      );
     });
     for (const [messageId, envelope] of messageRef.current.entries()) {
       const expiresAt =
@@ -1149,6 +1571,20 @@ function RoomPage({ roomId }: { roomId: string }) {
   useEffect(() => {
     void refreshInvites();
   }, [creatorToken, roomId]);
+
+  useEffect(() => {
+    roomStatusRef.current = room?.status ?? null;
+  }, [room?.status]);
+
+  useEffect(() => {
+    const urls = objectUrlsRef.current;
+    return () => {
+      for (const url of urls) {
+        URL.revokeObjectURL(url);
+      }
+      urls.clear();
+    };
+  }, []);
 
   async function handleSend(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1182,7 +1618,8 @@ function RoomPage({ roomId }: { roomId: string }) {
           senderSessionId: sessionId,
           plaintext: trimmed,
           sentAt,
-          expiresAt
+          expiresAt,
+          kind: "text"
         })
       );
     });
@@ -1446,7 +1883,16 @@ function RoomPage({ roomId }: { roomId: string }) {
                 style={bubbleStyle(message.senderSessionId, mine)}
               >
                 <span className="bubble-author">{mine ? "You" : "Guest"}</span>
-                <p>{message.plaintext}</p>
+                {message.kind === "file" && message.file ? (
+                  <FileCard
+                    file={message.file}
+                    onDownload={() =>
+                      handleRequestFile(message.file!.fileId, message.senderSessionId)
+                    }
+                  />
+                ) : (
+                  <p>{message.plaintext}</p>
+                )}
                 <footer>
                   <span>{formatClock(message.sentAt)}</span>
                   <span>{messageStatus(message)}</span>
@@ -1459,6 +1905,23 @@ function RoomPage({ roomId }: { roomId: string }) {
       </section>
 
       <form className="composer" onSubmit={handleSend}>
+        <button
+          aria-label="Attach file"
+          className="secondary-button composer-attach"
+          disabled={room?.status !== "open"}
+          onClick={() => fileInputRef.current?.click()}
+          title="Attach an encrypted file"
+          type="button"
+        >
+          &#128206;
+        </button>
+        <input
+          hidden
+          multiple
+          onChange={(event) => void handleAttachFiles(event.target.files)}
+          ref={fileInputRef}
+          type="file"
+        />
         <textarea
           value={draft}
           onChange={(event) => setDraft(event.target.value)}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -531,7 +531,7 @@ select {
 
 .composer {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: auto 1fr auto;
   gap: 8px;
   align-items: end;
   background: transparent;
@@ -539,6 +539,96 @@ select {
   box-shadow: none;
   backdrop-filter: none;
   padding: 0;
+}
+
+.composer-attach {
+  height: 48px;
+  width: 48px;
+  padding: 0;
+  font-size: 1.15rem;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.file-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.file-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.file-icon {
+  font-size: 1.3rem;
+  line-height: 1;
+}
+
+.file-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.file-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 32ch;
+}
+
+.file-size {
+  font-size: 0.74rem;
+  opacity: 0.7;
+}
+
+.file-status {
+  font-size: 0.76rem;
+  opacity: 0.75;
+}
+
+.file-status-error {
+  color: #c0392b;
+  opacity: 1;
+}
+
+.file-action {
+  align-self: flex-start;
+  padding: 4px 12px;
+  font-size: 0.82rem;
+}
+
+.file-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-progress-track {
+  flex: 1 1 auto;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor, transparent 82%);
+  overflow: hidden;
+}
+
+.file-progress-bar {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--bubble-accent, var(--accent, #6c5ce7));
+  transition: width 120ms ease;
+}
+
+.file-progress-label {
+  font-size: 0.74rem;
+  opacity: 0.75;
+  min-width: 3ch;
+  text-align: right;
 }
 
 .composer textarea {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -410,6 +410,24 @@ select {
   text-decoration: none;
 }
 
+.make-your-own {
+  margin: 22px auto 0;
+  max-width: 26rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.make-your-own-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.make-your-own-link:hover {
+  text-decoration: underline;
+}
+
 .participant-strip {
   display: flex;
   gap: 10px;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,2 +1,22 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  /**
+   * Cloudflare Turnstile site key. When set, the landing page runs an invisible
+   * Turnstile challenge before creating a room. Leave unset for local dev.
+   */
+  readonly VITE_TURNSTILE_SITE_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+interface Window {
+  turnstile?: {
+    render: (container: string | HTMLElement, options: Record<string, unknown>) => string;
+    execute: (widgetId: string, options?: Record<string, unknown>) => void;
+    reset: (widgetId?: string) => void;
+    remove: (widgetId: string) => void;
+  };
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,8 +4,10 @@ import { defineConfig } from "vite";
 // During local development the React app is served by Vite (HMR) on port 3000,
 // while the Cloudflare Worker + Durable Object run under `wrangler dev` on 8787.
 // Proxy the API surface (including the room WebSocket) to the Worker so the app
-// behaves exactly like production, where a single Worker serves both.
-const WORKER_ORIGIN = process.env.WORKER_ORIGIN ?? "http://localhost:8787";
+// behaves exactly like production, where a single Worker serves both. The Worker
+// runs on a dedicated port (see wrangler.jsonc `dev.port`) so it never collides
+// with other Cloudflare projects that also default to wrangler's port 8787.
+const WORKER_ORIGIN = process.env.WORKER_ORIGIN ?? "http://localhost:8799";
 
 export default defineConfig({
   plugins: [react()],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,24 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+// During local development the React app is served by Vite (HMR) on port 3000,
+// while the Cloudflare Worker + Durable Object run under `wrangler dev` on 8787.
+// Proxy the API surface (including the room WebSocket) to the Worker so the app
+// behaves exactly like production, where a single Worker serves both.
+const WORKER_ORIGIN = process.env.WORKER_ORIGIN ?? "http://localhost:8787";
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000
+    port: 3000,
+    proxy: {
+      "/api": {
+        target: WORKER_ORIGIN,
+        // Keep the original Host header (localhost:3000) so the Worker builds
+        // room/invite URLs on the dev-server origin instead of its own :8787.
+        changeOrigin: false,
+        ws: true
+      }
+    }
   }
 });
-

--- a/docs/GOOD-FIRST-ISSUES.md
+++ b/docs/GOOD-FIRST-ISSUES.md
@@ -1,0 +1,53 @@
+# Good First Issues
+
+Scoped starting points for new contributors. Copy any of these into a GitHub Issue (Issues → New) and add the `good first issue` label. Each is intentionally small and reviewable. Ordered roughly easiest → harder.
+
+---
+
+### 1. Add a "Create your own room" callout on the invite/room-gone screens
+**Type:** UX / growth · **Difficulty:** easy
+When a guest lands on an expired or used invite, or a room self-destructs, show a calm one-line prompt linking to `/` ("This secure room was made with elm.chat — create your own, free, no signup"). No tracking. This is the project's main organic-growth surface.
+
+### 2. Add a `robots.txt` and basic Open Graph / meta tags
+**Type:** SEO / polish · **Difficulty:** easy
+The landing page should have a title, description, OG image, and Twitter card so shared links render nicely. Keep it content-free about any room.
+
+### 3. Copy-to-clipboard confirmation for invite links
+**Type:** UX · **Difficulty:** easy
+Ensure "Share invite" and "Copy my link" show a clear, timed confirmation and are keyboard-accessible with `aria-live`.
+
+### 4. Respect `prefers-reduced-motion`
+**Type:** accessibility · **Difficulty:** easy
+Audit `styles.css` for animations/transitions and gate non-essential motion behind the media query.
+
+### 5. Keyboard & screen-reader pass on the composer and room controls
+**Type:** accessibility · **Difficulty:** medium
+Verify focus order, labels, and `aria-*` on the composer, Share/Destroy buttons, and participant strip. Document findings.
+
+### 6. Visible countdown for message vanish / room self-destruct
+**Type:** UX · **Difficulty:** medium
+Show a live countdown (or relative "vanishes in ~3m") so users understand the ephemeral policy at a glance.
+
+### 7. Graceful reconnect on WebSocket drop
+**Type:** reliability · **Difficulty:** medium
+When the room socket drops (mobile network flap), attempt bounded reconnection with clear UI state instead of a dead room.
+
+### 8. Configurable invite TTL in the UI
+**Type:** feature · **Difficulty:** medium
+Let the creator choose invite lifetime when issuing a one-time invite (default short). Enforce server-side.
+
+### 9. Add "Deploy to Cloudflare" end-to-end test / docs verification
+**Type:** infra / docs · **Difficulty:** medium
+Verify the one-click deploy provisions the Durable Object correctly on a fresh account; document any manual steps.
+
+### 10. Threat-model diagram
+**Type:** docs / security · **Difficulty:** medium
+Produce a clear diagram of trust boundaries (client, Worker, Durable Object, URL fragment) for `docs/threat-model.md`.
+
+### 11. Metadata-minimization audit of the Worker
+**Type:** security · **Difficulty:** hard
+Enumerate everything the Worker/Durable Object can observe per room (IPs, timing, sizes) and propose reductions. Write it up as a doc + issues.
+
+### 12. Independent review of the crypto package
+**Type:** security · **Difficulty:** hard
+Review `packages/crypto` key exchange and message encryption against the stated threat model. File findings via SECURITY.md, not public issues.

--- a/docs/abuse-policy.md
+++ b/docs/abuse-policy.md
@@ -1,0 +1,41 @@
+# Acceptable Use & Abuse Policy
+
+elm.chat provides private, ephemeral, end-to-end encrypted rooms. Privacy exists to protect people — not to shield abuse. This policy explains what is not allowed, how the design limits our ability (and anyone's) to see content, and how to report a problem.
+
+## What is not allowed
+
+Do not use elm.chat to:
+
+- create, share, or solicit child sexual abuse material (CSAM) or any content that sexualizes minors;
+- coordinate violence, terrorism, or credible threats against people;
+- traffic humans, weapons, or controlled substances;
+- distribute malware or conduct attacks against others;
+- harass, stalk, dox, or impersonate;
+- infringe others' intellectual property.
+
+## What we can and cannot see
+
+By design, elm.chat minimizes what the server can observe:
+
+- message content is **end-to-end encrypted** in the browser;
+- the **room secret lives in the URL fragment** and does not normally reach the server;
+- rooms are **short-lived and self-destruct**; there is no persistent transcript archive on the server.
+
+This means that for most reports we **cannot** read message content or reconstruct a conversation, even if asked — that is the point of the tool. What we can act on are abuse vectors we control: bot-driven room creation (mitigated by Cloudflare Turnstile), and publicly advertised rooms or invite links that are reported to us.
+
+## Reporting abuse
+
+If you encounter content or behavior that violates this policy:
+
+- **On the public instance:** email the maintainer (contact on the GitHub profile) with the room code and/or invite link and a description. Because rooms self-destruct, report quickly — the room may already be gone.
+- **CSAM:** we report to the appropriate authorities (e.g., NCMEC in the US) and cooperate with lawful requests to the extent technically possible.
+
+## For self-hosters
+
+If you deploy your own instance (via the Deploy to Cloudflare button or a fork), **you are the operator** and are responsible for its acceptable use, abuse handling, and compliance with local law. We strongly recommend: keep Turnstile enabled, keep room/message lifetimes short, publish your own contact for reports, and do not advertise the instance for illegal use.
+
+## Enforcement
+
+On instances we operate, we may block room creation from abusive sources, cooperate with lawful legal process, and remove publicly advertised invite links that violate this policy. We cannot retroactively access content that the architecture prevents us from seeing.
+
+*This policy will evolve as the project matures. It is not legal advice.*

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,8 +1,24 @@
 # API Spec
 
+All API responses are sent with `no-store` caching and hardening headers (`Referrer-Policy: no-referrer`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and a strict `Content-Security-Policy`).
+
 ## `POST /api/rooms`
 
-Creates a room and bootstraps its signaling Durable Object.
+Creates a room and bootstraps its Durable Object.
+
+Request body (all fields optional):
+
+```json
+{
+  "disappearAfterReadSeconds": 420,
+  "inactivityTimeoutMs": 600000,
+  "maxAgeMs": null,
+  "turnstileToken": "optional-turnstile-token"
+}
+```
+
+- A `null` duration means "indefinite" (no message expiry / no idle timeout).
+- If the Worker has `TURNSTILE_SECRET` configured, `turnstileToken` is required and verified; otherwise it is ignored.
 
 Response `201`:
 
@@ -16,8 +32,14 @@ Response `201`:
   "inactivityTimeoutMs": 600000,
   "maxAgeMs": null,
   "disappearAfterReadSeconds": 420,
-  "creatorToken": "creator-only-destroy-capability"
+  "creatorToken": "creator-only-capability"
 }
+```
+
+Response `403` when Turnstile is enabled and verification fails:
+
+```json
+{ "error": "Bot verification failed. Please try again." }
 ```
 
 ## `GET /api/rooms/:roomId`
@@ -41,65 +63,89 @@ Response `200`:
 }
 ```
 
-## `GET /api/rooms/:roomId/ws`
+## `POST /api/rooms/:roomId/destroy`
 
-Upgrades to a WebSocket used only for signaling and room control.
-
-### Client events
+Creator-only. Marks the room destroyed and disconnects everyone.
 
 ```json
-{ "type": "join", "sessionId": "uuid", "creatorToken": "optional" }
+{ "creatorToken": "creator-only-capability" }
+```
+
+## Invites
+
+One-time invites let non-creators join. All three routes are creator-only.
+
+- `POST /api/rooms/:roomId/invites` — body `{ "creatorToken": "...", "ttlMs": 600000 }`, returns the created invite (`201`).
+- `GET  /api/rooms/:roomId/invites?creatorToken=...` — lists invites.
+- `POST /api/rooms/:roomId/invites/revoke` — body `{ "creatorToken": "...", "token": "invite-token" }`; revokes and disconnects the consuming participant if connected.
+
+Invite shape:
+
+```json
 {
-  "type": "signal",
-  "toSessionId": "uuid",
-  "signal": { "type": "offer", "sdp": "..." }
+  "token": "invite-token",
+  "createdAt": 1744150000000,
+  "expiresAt": 1744150600000,
+  "consumedAt": 1744150100000,
+  "consumedBySessionId": "uuid",
+  "revokedAt": null
 }
-{
-  "type": "signal",
-  "toSessionId": "uuid",
-  "signal": { "type": "answer", "sdp": "..." }
-}
-{
-  "type": "signal",
-  "toSessionId": "uuid",
-  "signal": {
-    "type": "ice",
-    "candidate": "candidate:...",
-    "sdpMid": "0",
-    "sdpMLineIndex": 0
-  }
-}
-{ "type": "destroy", "creatorToken": "creator-only-token" }
+```
+
+An invite link is `/(c)/:roomId?invite=<token>#<room_secret>`.
+
+## `GET /api/turn-credentials`
+
+Returns STUN/ICE servers (and short-lived TURN credentials if `TURN_SECRET` + `TURN_URLS` are configured). **Reserved for the currently-disabled WebRTC path; the shipping relay client does not call it.**
+
+## `GET /api/rooms/:roomId/ws`
+
+Upgrades to the room WebSocket. This carries both control and **relayed encrypted content** (see Peer Data Protocol).
+
+### Client → server events
+
+```json
+{ "type": "join", "sessionId": "uuid", "identityKey": "base64url-ecdsa-pubkey", "creatorToken": "optional", "inviteToken": "optional" }
+{ "type": "peer_data", "toSessionId": "uuid-or-omitted", "data": { /* see Peer Data Protocol */ } }
+{ "type": "signal", "toSessionId": "uuid", "signal": { "type": "offer|answer|ice", "sdp": "...", "candidate": "..." } }
+{ "type": "kick_participant", "creatorToken": "creator-only", "targetSessionId": "uuid" }
+{ "type": "destroy", "creatorToken": "creator-only" }
 { "type": "ping" }
 ```
 
-### Server events
+- `peer_data` with `toSessionId` omitted is broadcast to all other participants; with `toSessionId` set it is relayed to that one session.
+- `signal` is the dormant WebRTC signaling relay (unused while `peerTransportEnabled` is false).
+
+### Server → client events
 
 ```json
-{
-  "type": "joined",
-  "room": {},
-  "sessionId": "uuid",
-  "creator": true,
-  "peers": [{ "sessionId": "uuid-2", "creator": false, "connectedAt": 1744150200000 }],
-  "presence": { "count": 2, "connectedSessionIds": ["uuid", "uuid-2"] }
-}
+{ "type": "joined", "room": { /* metadata */ }, "sessionId": "uuid", "creator": true,
+  "peers": [{ "sessionId": "uuid-2", "creator": false, "connectedAt": 1744150200000, "identityKey": "base64url" }],
+  "presence": { "count": 2, "connectedSessionIds": ["uuid", "uuid-2"] } }
 { "type": "presence", "presence": { "count": 2, "connectedSessionIds": ["uuid-1", "uuid-2"] } }
-{ "type": "peer_joined", "peer": { "sessionId": "uuid-3", "creator": false, "connectedAt": 1744150300000 } }
+{ "type": "peer_joined", "peer": { "sessionId": "uuid-3", "creator": false, "connectedAt": 1744150300000, "identityKey": "base64url" } }
 { "type": "peer_left", "sessionId": "uuid-2" }
+{ "type": "peer_data", "fromSessionId": "uuid-2", "data": { /* see Peer Data Protocol */ } }
 { "type": "signal", "fromSessionId": "uuid-2", "signal": { "type": "offer", "sdp": "..." } }
+{ "type": "participant_kicked", "sessionId": "uuid", "reason": "kicked" }
 { "type": "room_state", "status": "destroyed", "expiresAt": null, "reason": "destroyed" }
-{ "type": "error", "code": "peer_missing", "message": "Peer is no longer connected." }
+{ "type": "error", "code": "invite_required", "message": "A valid one-time invite is required." }
 ```
 
-## Peer Data Channel Protocol
+## Peer Data Protocol
 
-These events move directly between browsers, not through the server:
+These events are the end-to-end encrypted payloads carried inside `peer_data`. They are **relayed through the Durable Object** (broadcast, or targeted via `toSessionId`); the server forwards ciphertext and cannot read them.
 
 ```json
 { "type": "chat_message", "envelope": { "messageId": "uuid", "senderSessionId": "uuid", "ciphertext": "base64url", "nonce": "base64url", "sentAt": 1744150200000, "expiresAfterReadSeconds": 420 } }
 { "type": "sync_request" }
-{ "type": "sync_response", "messages": [{ "messageId": "uuid", "senderSessionId": "uuid", "ciphertext": "base64url", "nonce": "base64url", "sentAt": 1744150200000, "expiresAfterReadSeconds": 420 }] }
+{ "type": "sync_response", "messages": [ /* array of envelopes, capped to MAX_TRANSCRIPT_SYNC_MESSAGES */ ] }
 { "type": "peer_destroy" }
-{ "type": "file_offer", "fileId": "uuid", "name": "example.pdf", "mimeType": "application/pdf", "size": 12345 }
+
+{ "type": "file_offer", "fileId": "uuid", "senderSessionId": "uuid", "name": "example.pdf", "mimeType": "application/pdf", "size": 12345, "sentAt": 1744150200000, "expiresAfterReadSeconds": 420 }
+{ "type": "file_request", "fileId": "uuid" }
+{ "type": "file_chunk", "fileId": "uuid", "chunkIndex": 0, "totalChunks": 4, "ciphertext": "base64url", "nonce": "base64url" }
+{ "type": "file_complete", "fileId": "uuid" }
 ```
+
+**File flow:** the sender broadcasts a `file_offer`; a recipient sends a targeted `file_request`; the sender streams encrypted `file_chunk`s (targeted) followed by `file_complete`; the recipient decrypts, reassembles, and offers a download. File contents are never stored server-side and vanish on the room's message policy.

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -94,10 +94,6 @@ Invite shape:
 
 An invite link is `/(c)/:roomId?invite=<token>#<room_secret>`.
 
-## `GET /api/turn-credentials`
-
-Returns STUN/ICE servers (and short-lived TURN credentials if `TURN_SECRET` + `TURN_URLS` are configured). **Reserved for the currently-disabled WebRTC path; the shipping relay client does not call it.**
-
 ## `GET /api/rooms/:roomId/ws`
 
 Upgrades to the room WebSocket. This carries both control and **relayed encrypted content** (see Peer Data Protocol).
@@ -107,14 +103,12 @@ Upgrades to the room WebSocket. This carries both control and **relayed encrypte
 ```json
 { "type": "join", "sessionId": "uuid", "identityKey": "base64url-ecdsa-pubkey", "creatorToken": "optional", "inviteToken": "optional" }
 { "type": "peer_data", "toSessionId": "uuid-or-omitted", "data": { /* see Peer Data Protocol */ } }
-{ "type": "signal", "toSessionId": "uuid", "signal": { "type": "offer|answer|ice", "sdp": "...", "candidate": "..." } }
 { "type": "kick_participant", "creatorToken": "creator-only", "targetSessionId": "uuid" }
 { "type": "destroy", "creatorToken": "creator-only" }
 { "type": "ping" }
 ```
 
 - `peer_data` with `toSessionId` omitted is broadcast to all other participants; with `toSessionId` set it is relayed to that one session.
-- `signal` is the dormant WebRTC signaling relay (unused while `peerTransportEnabled` is false).
 
 ### Server → client events
 
@@ -126,7 +120,6 @@ Upgrades to the room WebSocket. This carries both control and **relayed encrypte
 { "type": "peer_joined", "peer": { "sessionId": "uuid-3", "creator": false, "connectedAt": 1744150300000, "identityKey": "base64url" } }
 { "type": "peer_left", "sessionId": "uuid-2" }
 { "type": "peer_data", "fromSessionId": "uuid-2", "data": { /* see Peer Data Protocol */ } }
-{ "type": "signal", "fromSessionId": "uuid-2", "signal": { "type": "offer", "sdp": "..." } }
 { "type": "participant_kicked", "sessionId": "uuid", "reason": "kicked" }
 { "type": "room_state", "status": "destroyed", "expiresAt": null, "reason": "destroyed" }
 { "type": "error", "code": "invite_required", "message": "A valid one-time invite is required." }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,12 +30,12 @@ Content is end-to-end encrypted in the browser and **relayed — never stored �
 
 ### Why relay instead of peer-to-peer
 
-A WebRTC scaffold exists (signaling relay, ICE handling, offer/answer) but is **intentionally disabled** (`peerTransportEnabled = false`, and no data channels are created). Relaying encrypted payloads through the Durable Object is a deliberate choice for this threat model:
+elm-chat does **not** use WebRTC peer-to-peer transport, and it contacts **no STUN or TURN servers**. Relaying encrypted payloads through the Durable Object is a deliberate choice for this threat model:
 
 - **Peer IP addresses stay private.** With relay, participants never connect directly, so no room member learns another member's IP. WebRTC would expose peer IPs to everyone in the room via ICE candidates — a regression for a coercion/surveillance threat model where an invitee may be hostile.
 - **No TURN dependency, works everywhere.** Direct P2P fails on symmetric NAT, mobile carriers, and restrictive networks without a TURN relay. Relaying through the Worker is reliable globally.
 
-The trade-off is that the honest-but-curious server relays ciphertext and observes connection metadata (timing, sizes, presence). `stun.cloudflare.com` and the `/api/turn-credentials` endpoint are referenced only by the dormant WebRTC path and are **not used** by the shipping app.
+The trade-off is that the honest-but-curious server relays ciphertext and observes connection metadata (timing, sizes, presence). Direct peer transport (with its IP-exposure trade-off) remains a possible future option, but is not part of the current implementation.
 
 ## Data Placement
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,88 +2,95 @@
 
 ## Overview
 
-`elm-chat` is now a peer-to-peer room application with a signaling-only server path:
+`elm-chat` is a disposable, end-to-end encrypted room application. A single Cloudflare Worker serves the app and API; one Durable Object per room coordinates live transport. All message and file content is encrypted in the browser under a room key derived from a secret that never leaves the URL fragment.
 
-- `apps/web`: React SPA for room creation, browser crypto, WebRTC transport, transcript sync, and chat UI.
-- `workers/api`: Cloudflare Worker serving the SPA, room APIs, and WebSocket upgrade routing.
-- `durable-objects/room`: one Durable Object per room for membership, signaling relay, presence, expiry, and destroy state.
-- `packages/shared`: shared protocol contracts for room lifecycle, signaling, and peer data events.
-- `packages/crypto`: browser-side HKDF + AES-GCM helpers using Web Crypto.
+- `apps/web`: React SPA — room creation, browser crypto, chat + file UI, transport client.
+- `workers/api`: Cloudflare Worker — serves the SPA, room + invite APIs, Turnstile verification, and WebSocket routing.
+- `durable-objects/room`: one Durable Object per room — membership, presence, encrypted-payload relay, invites, expiry, and destroy state.
+- `packages/shared`: shared protocol contracts for room lifecycle, transport events, and peer data events.
+- `packages/crypto`: browser-side HKDF + AES-GCM + ECDSA helpers over Web Crypto.
 
-## Transport Model
+## Transport Model (encrypted relay)
 
-The server no longer relays or stores chat messages.
+Content is end-to-end encrypted in the browser and **relayed — never stored —** through the room's Durable Object over a single WebSocket. The server forwards ciphertext and cannot read it.
 
-1. The landing page generates a random `room_secret` in the browser.
-2. `POST /api/rooms` creates room metadata plus a per-room signaling Durable Object.
+1. The landing page generates a random 256-bit `room_secret` in the browser.
+2. `POST /api/rooms` creates room metadata plus the per-room Durable Object (optionally gated by an invisible Turnstile challenge).
 3. The browser navigates to `/c/:roomId#<room_secret>`.
-4. The client derives `K_room` locally from the fragment secret.
-5. The client opens a WebSocket to the room Durable Object, but only for:
-   - room join
-   - peer presence
-   - SDP offer / answer relay
-   - ICE candidate relay
-   - room destroy
+4. The client derives `K_room` locally from the fragment secret with HKDF-SHA-256.
+5. The client opens one WebSocket to the room Durable Object, used for:
+   - room join and presence
+   - encrypted chat message relay
+   - encrypted file transfer relay
+   - transcript sync between participants
+   - participant removal (kick) and room destroy
    - keepalive pings
-6. Peer browsers establish direct `RTCDataChannel` links to each other.
-7. Encrypted message envelopes move only across peer data channels.
-8. When a new participant joins, they request transcript sync from connected peers.
+6. The Durable Object relays each encrypted envelope to other participants — either broadcast to everyone else, or targeted to a single `sessionId` (used for file chunks and per-peer transcript sync).
+7. When a new participant joins, they request transcript sync from connected peers; peers reply with their local encrypted history (relayed), capped to `MAX_TRANSCRIPT_SYNC_MESSAGES`.
+
+### Why relay instead of peer-to-peer
+
+A WebRTC scaffold exists (signaling relay, ICE handling, offer/answer) but is **intentionally disabled** (`peerTransportEnabled = false`, and no data channels are created). Relaying encrypted payloads through the Durable Object is a deliberate choice for this threat model:
+
+- **Peer IP addresses stay private.** With relay, participants never connect directly, so no room member learns another member's IP. WebRTC would expose peer IPs to everyone in the room via ICE candidates — a regression for a coercion/surveillance threat model where an invitee may be hostile.
+- **No TURN dependency, works everywhere.** Direct P2P fails on symmetric NAT, mobile carriers, and restrictive networks without a TURN relay. Relaying through the Worker is reliable globally.
+
+The trade-off is that the honest-but-curious server relays ciphertext and observes connection metadata (timing, sizes, presence). `stun.cloudflare.com` and the `/api/turn-credentials` endpoint are referenced only by the dormant WebRTC path and are **not used** by the shipping app.
 
 ## Data Placement
 
-### Server-side
+### Server-side (Durable Object storage, persisted)
 
-Persisted in Durable Object storage:
+- room metadata (policy, status, timestamps)
+- creator destroy capability (creator token)
+- one-time invites
 
-- room metadata
-- creator destroy capability
-- expiry configuration
+### Relayed but never persisted server-side
 
-Not persisted server-side:
+- encrypted chat message envelopes
+- encrypted file chunks
+- transcript sync payloads
 
-- plaintext messages
-- ciphertext messages
-- file contents
-- transcript history
+### Not visible to the server at all
 
-Session membership is kept in memory on the Durable Object while sockets are connected.
+- plaintext of any kind
+- the room secret (kept in the URL fragment)
+- other participants' IP addresses (peers never connect directly to each other)
 
 ### Client-side
 
-Each connected participant keeps the current encrypted transcript in memory and can replay it to newly connected peers. If no connected peer still holds a message, that message is gone.
+Each connected participant keeps the current encrypted transcript in memory and can replay it to newly connected peers. A file being sent is held in memory by the sender until a peer requests it or it expires. If no connected peer still holds a message or file, it is gone.
 
-## Peer Mesh Rules
+## Encryption
 
-- Each room participant gets a WebSocket signaling session plus zero or more peer data channels.
-- The lexicographically smaller `sessionId` offers first to avoid symmetric-offer glare in normal join flow.
-- Existing peers respond to `sync_request` with their local encrypted transcript, capped to the most recent `MAX_TRANSCRIPT_SYNC_MESSAGES`.
-- Transcript collation on join is client-side and de-duplicates by `messageId`.
+- **Room key:** HKDF-SHA-256 over the fragment secret → AES-GCM-256.
+- **Messages:** AES-GCM per message with a random 96-bit nonce; transmitted as a base64url envelope.
+- **Files:** chunked at `FILE_CHUNK_BYTES` (64 KiB). Each chunk is AES-GCM-encrypted with its own nonce, streamed over the relay to the requesting peer, then reassembled and decrypted by the recipient. Max size `MAX_FILE_BYTES` (25 MiB).
+- **Identity keys:** each client generates an ephemeral ECDSA P-256 keypair and shares the public key on join. This is reserved for future message authentication and is not yet used to verify messages.
 
-## Security Boundaries
+## Membership & Relay Rules
 
-- The URL fragment contains the room secret and is not sent to the server in standard HTTP requests.
-- The Worker and Durable Object see room IDs, session IDs, peer signaling metadata, and lifecycle state only.
-- Peers exchange encrypted envelopes over data channels even though WebRTC already encrypts transport.
-- There is no server-side transcript recovery path.
+- The set of connected participants is derived from **live WebSocket attachments**, not an in-memory map. This survives Durable Object hibernation, so targeted relays (file chunks, per-peer sync) keep working after the object sleeps and wakes.
+- Broadcasts (chat, presence, peer join/leave) go to all other participants; targeted relays go to one `sessionId`.
+- Room capacity is capped at `MAX_CONNECTIONS_PER_ROOM`.
+- Transcript collation on join de-duplicates by `messageId`.
 
-## File Transfer Direction
+## Access Control
 
-The current codebase defines the peer-data protocol in a way that allows direct file offer / transfer events, but full file transfer UX is not implemented yet.
+- The creator holds the creator token (stored in the browser's `localStorage`) and can issue single-use invites, revoke invites, and remove participants.
+- Non-creators must present a valid one-time invite to join. The session that consumes an invite may reconnect (e.g. a page reload), but the invite cannot be reused by a different session, and revoking it disconnects the consuming participant.
 
-The intended model is:
+## Abuse Prevention
 
-- files move over peer data channels or negotiated out-of-band peer transfer paths
-- the server acts only as signaling / room coordination
-- no storage bucket is used by default for sensitive rooms
+- Optional Cloudflare Turnstile (invisible) on room creation. The client runs the challenge when a site key is configured; the Worker verifies the token when `TURNSTILE_SECRET` is set. It stays fully inert (open creation) when unconfigured, so local dev and unconfigured deploys keep working.
 
 ## Safety Constraints
 
-This design improves ephemerality and reduces server visibility, but it does not eliminate:
+Relaying encrypted content reduces what the server can read, but it does not eliminate:
 
 - device compromise
-- malicious room participants
+- malicious room participants (anyone who decrypts can copy plaintext)
 - screenshots or copied plaintext
-- traffic analysis against peers
-- TURN-provider metadata exposure when relay is required
+- traffic analysis against the relay (message timing and size are observable)
 
-For high-risk deployments, TURN, mobile network behavior, denial-of-service handling, and peer authentication need explicit operational review.
+The server still relays ciphertext and observes connection metadata. For high-risk deployments, denial-of-service handling, message authentication, and mobile-network reliability need explicit operational review.

--- a/docs/room-lifecycle.md
+++ b/docs/room-lifecycle.md
@@ -3,41 +3,54 @@
 ## Creation
 
 - the browser generates a random 256-bit room secret
-- the Worker creates a room ID and creator token
-- the Worker bootstraps a signaling Durable Object
-- the client navigates to `/c/:roomId#<room_secret>`
+- the Worker creates a room ID and creator token (optionally after an invisible Turnstile check)
+- the Worker bootstraps the room's Durable Object
+- the client navigates to `/c/:roomId#<room_secret>` and stores the creator token in `localStorage`
 
 ## Join
 
-- each tab generates a random session ID
+- each tab generates a random session ID (kept in `sessionStorage`) and an ephemeral ECDSA identity keypair
 - the client derives the room key locally with HKDF
-- the client joins the room over WebSocket for signaling only
-- the Durable Object returns currently connected peers
-- the browser starts WebRTC peer connections to those peers
+- the client opens the room WebSocket and sends `join` with its session ID, identity public key, and either the creator token or a one-time invite token
+- the creator joins with the creator token; everyone else must present a valid, unconsumed, unrevoked invite
+- the session that consumed an invite may reconnect (e.g. reload) with the same invite; a different session cannot reuse it
+- the Durable Object returns currently connected peers and presence
 
 ## Active Messaging
 
-- senders encrypt plaintext in the browser
-- encrypted envelopes move over peer data channels only
-- each connected participant keeps transcript state in local memory
-- the server does not persist message history
+- senders encrypt plaintext in the browser (AES-GCM under the room key)
+- encrypted envelopes are relayed through the Durable Object to other participants
+- each connected participant also keeps transcript state in local memory
+- the server relays ciphertext but never persists message history
+
+## File Sharing
+
+- the sender picks a file (up to 25 MiB), which stays in the sender's browser memory
+- a `file_offer` is broadcast; recipients see an "incoming file" card
+- on download, the recipient sends a `file_request`; the sender streams AES-GCM-encrypted 64 KiB chunks (relayed, targeted to the requester), then `file_complete`
+- the recipient decrypts, reassembles, and downloads; file contents are never stored server-side and expire on the room's message policy
 
 ## Transcript Collation
 
 - when a new participant connects, they ask peers for transcript sync
-- connected peers respond with their current encrypted history
+- connected peers respond with their current encrypted history (relayed)
 - the new participant de-duplicates by `messageId` and decrypts locally
 - if no connected peer still has a message, it is gone
 
+## Participant Removal
+
+- the creator can remove a participant (`kick_participant`); the target receives `participant_kicked` and is disconnected
+- revoking a consumed invite also disconnects the participant who used it
+
 ## Expiry
 
-- message expiry is enforced locally by peers using the room policy
-- room expiry is enforced by the signaling Durable Object using lifecycle metadata
-- if the room expires or is destroyed, the server closes signaling sockets and peers shut down their mesh
+- message expiry is enforced locally by each client using the room policy
+- room expiry is enforced by the Durable Object using lifecycle metadata (idle timeout and/or max age), via an alarm
+- if the room expires or is destroyed, the Durable Object closes all sockets and broadcasts `room_state`
 
 ## Manual Destroy
 
 - the creator uses the creator token returned at room creation
 - the Worker forwards the destroy request to the Durable Object
-- the Durable Object marks the room as destroyed and closes signaling sockets
-- connected peers also receive a direct `peer_destroy` control event when possible
+- the Durable Object marks the room destroyed and closes all sockets
+- connected clients also receive a `peer_destroy` relayed control event where possible

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -6,101 +6,88 @@
 - room secret in the fragment
 - derived room encryption key
 - peer session IDs
-- encrypted transcript held by connected peers
-- creator destroy capability
+- encrypted transcript and files held by connected clients
+- creator destroy capability and one-time invites
 
 ## Security Goal
 
-Minimize server-side visibility and persistence so the application can be used with lower central trust than a store-and-forward chat service.
+Minimize what the server can read and retain, so the application can be used with lower central trust than a store-and-forward chat service. Content is end-to-end encrypted; the server relays ciphertext and never persists messages or files.
 
 ## Trust Assumptions
 
-- browsers provide correct Web Crypto and WebRTC implementations
+- browsers provide correct Web Crypto implementations
 - users verify and protect capability links out of band
-- connected peers are not automatically trusted with plaintext once they decrypt
-- the signaling Worker / Durable Object is honest-but-curious, not trusted with content
+- connected participants are not automatically trusted with plaintext once they decrypt
+- the Worker / Durable Object is honest-but-curious: it relays and coordinates, but is not trusted with content
 
 ## Primary Threats
 
 ### Link leakage
 
-Anyone with the full capability URL can derive the room key and impersonate a participant.
+Anyone with the full capability URL can derive the room key and (with a valid invite or the creator token) participate.
 
 Current mitigations:
 
-- room secret stays in the fragment
+- room secret stays in the URL fragment and is not sent in normal HTTP requests
 - strict `Referrer-Policy: no-referrer`
+- one-time invites for non-creators; creator can revoke invites and remove participants
 - no third-party analytics on room pages
 
 ### Server compromise or insider access
 
-The signaling layer can see peer metadata but should not see transcript content.
+The relay can see connection metadata and ciphertext, but not plaintext.
 
 Current mitigations:
 
-- server only handles room lifecycle and peer signaling
-- no server-side transcript persistence
-- peers exchange encrypted envelopes directly
+- all message and file content is end-to-end encrypted in the browser
+- no server-side transcript or file persistence (only room metadata and invites are stored)
+- the room secret never reaches the server
 
 Residual risk:
 
-- signaling metadata still reveals room activity and participant timing
+- the server **does relay ciphertext**, so it observes message/file timing, sizes, and participant presence
+- an attacker with full server control could perform traffic analysis on this metadata
+
+### Peer IP exposure
+
+Because content is relayed (not sent peer-to-peer), participants never connect directly, so **no room member learns another member's IP address**. This is a deliberate advantage over a naive WebRTC design, where ICE negotiation would reveal peer IPs to everyone in the room. Cloudflare's edge still sees each client's IP, as with any hosted service.
 
 ### Peer compromise
 
-Any connected peer can exfiltrate plaintext after local decryption.
-
-Not solved by this design:
+Any connected participant can exfiltrate plaintext after local decryption. Not solved by this design:
 
 - screenshots
 - copy / paste
 - malicious local extensions
 - infected devices
 
-### Connectivity coercion and relay visibility
-
-Peer-to-peer systems may need TURN relays when direct connectivity fails. Relay operators can still observe metadata such as byte volume and timing even if they cannot decrypt payloads.
-
-Operational requirement:
-
-- use short-lived TURN credentials
-- separate TURN operations from transcript storage
-- assume relay metadata is observable
-
 ### Transcript loss
 
-Because the server does not persist messages, transcript continuity depends on connected peers retaining encrypted history in memory.
-
-Consequence:
-
-- if no connected peer still has a message, it cannot be recovered
-
-This is intentional for ephemerality, but it is a usability and reliability tradeoff.
+Because the server does not persist messages, transcript continuity depends on connected clients retaining encrypted history in memory. If no connected participant still has a message, it cannot be recovered. This is intentional for ephemerality, and a usability trade-off.
 
 ### Traffic analysis
 
-An adversary observing network patterns may infer room activity, peer presence, or message bursts without decrypting content.
+An adversary observing the relay or network can infer room activity, presence, and message/file bursts without decrypting content. Not solved in the current implementation: timing obfuscation, padding, cover traffic.
 
-Not solved in the current implementation:
+### Availability / abuse
 
-- timing obfuscation
-- packet padding
-- cover traffic
+Optional invisible Turnstile on room creation limits automated room-creation spam. There is no per-message rate limiting or DoS protection beyond room capacity and expiry.
 
 ## Non-Goals In Current Build
 
-- strong anonymous routing
+- strong anonymous routing (metadata hiding from the relay)
 - deniable messaging
 - authenticated human identity
 - forward secrecy beyond a shared static room key
 - verified peer device trust
+- message authentication (ephemeral identity keys are exchanged but not yet used to verify messages)
 
 ## High-Risk Use Warning
 
-This architecture is safer than the previous ciphertext-buffering relay, but it is not yet sufficient to claim strong protection for people under severe repression. A production-safe deployment still needs:
+This design is E2E encrypted and ephemeral, but it is not sufficient to claim strong protection for people under severe repression. A production-safe deployment for high-risk users would still need:
 
-- audited TURN strategy
-- stronger peer authentication or device continuity model
-- replay / duplicate protections beyond message ID de-duplication
-- mobile network failure testing
+- message authentication and replay/duplicate protections
+- stronger peer/device trust model
+- traffic-analysis resistance
+- denial-of-service handling
 - clear user education about participant trust and device compromise

--- a/durable-objects/room/src/room.ts
+++ b/durable-objects/room/src/room.ts
@@ -18,9 +18,7 @@ import {
   type RoomInvite,
   type RoomMetadata,
   type RoomStateEvent,
-  type ServerEvent,
-  type SignalEvent,
-  type SignalPayload
+  type ServerEvent
 } from "@elm-chat/shared";
 import { DurableObject } from "cloudflare:workers";
 
@@ -205,9 +203,6 @@ export class RoomDurableObject extends DurableObject<Env> {
       case "join":
         await this.handleJoin(ws, parsed);
         break;
-      case "signal":
-        await this.handleSignal(ws, parsed);
-        break;
       case "peer_data":
         await this.handlePeerData(ws, parsed);
         break;
@@ -351,31 +346,6 @@ export class RoomDurableObject extends DurableObject<Env> {
     } satisfies PeerJoinedEvent);
 
     await this.broadcastPresence();
-    await this.markRoomActivity();
-  }
-
-  private async handleSignal(ws: WebSocket, payload: SignalPayload): Promise<void> {
-    if (!this.roomMeta || this.roomMeta.status !== "open") {
-      ws.send(JSON.stringify(errorEvent("room_unavailable", "Room is unavailable.")));
-      return;
-    }
-
-    const attachment = ws.deserializeAttachment() as AttachmentRecord | null;
-    if (!attachment?.sessionId) {
-      ws.send(JSON.stringify(errorEvent("join_required", "Join before sending peer signals.")));
-      return;
-    }
-
-    if (!this.isConnected(payload.toSessionId)) {
-      ws.send(JSON.stringify(errorEvent("peer_missing", "Peer is no longer connected.")));
-      return;
-    }
-
-    this.broadcastToSessions([payload.toSessionId], {
-      type: "signal",
-      fromSessionId: attachment.sessionId,
-      signal: payload.signal
-    } satisfies SignalEvent);
     await this.markRoomActivity();
   }
 

--- a/durable-objects/room/src/room.ts
+++ b/durable-objects/room/src/room.ts
@@ -28,15 +28,15 @@ type RoomStorage = RoomMetadata & {
   creatorToken: string;
 };
 
-type SessionRecord = {
-  sessionId: string;
-  creator: boolean;
-  connectedAt: number;
-  identityKey: string;
-};
-
+// Stored on each accepted WebSocket via serializeAttachment. This survives
+// Durable Object hibernation, so it — not an in-memory map — is the source of
+// truth for who is connected. An empty sessionId marks a socket that has been
+// accepted but has not completed a join yet.
 type AttachmentRecord = {
   sessionId: string;
+  creator: boolean;
+  identityKey: string;
+  connectedAt: number;
 };
 
 type RoomBootstrap = Pick<
@@ -85,7 +85,6 @@ async function safeJson<T>(request: Request): Promise<T> {
 
 export class RoomDurableObject extends DurableObject<Env> {
   private roomMeta: RoomStorage | null = null;
-  private sessions = new Map<string, SessionRecord>();
   private invites = new Map<string, RoomInvite>();
   private storageReady: Promise<void>;
 
@@ -146,7 +145,12 @@ export class RoomDurableObject extends DurableObject<Env> {
       const pair = new WebSocketPair();
       const [client, server] = Object.values(pair);
       this.ctx.acceptWebSocket(server);
-      server.serializeAttachment({ sessionId: "" } satisfies AttachmentRecord);
+      server.serializeAttachment({
+        sessionId: "",
+        creator: false,
+        identityKey: "",
+        connectedAt: 0
+      } satisfies AttachmentRecord);
       await this.markRoomActivity();
       return wsResponse(client);
     }
@@ -172,7 +176,10 @@ export class RoomDurableObject extends DurableObject<Env> {
       typeof this.roomMeta.inactivityTimeoutMs === "number" &&
       idleFor >= this.roomMeta.inactivityTimeoutMs
     ) {
-      await this.transitionRoom("expired", this.sessions.size === 0 ? "join-timeout" : "inactive");
+      await this.transitionRoom(
+        "expired",
+        this.connectedSessionIds().length === 0 ? "join-timeout" : "inactive"
+      );
       return;
     }
 
@@ -223,7 +230,6 @@ export class RoomDurableObject extends DurableObject<Env> {
       return;
     }
 
-    this.sessions.delete(attachment.sessionId);
     await this.markRoomActivity();
     this.broadcast({
       type: "peer_left",
@@ -308,23 +314,22 @@ export class RoomDurableObject extends DurableObject<Env> {
       }
     }
 
-    const session: SessionRecord = {
+    const session: AttachmentRecord = {
       sessionId: payload.sessionId,
       creator,
       connectedAt: Date.now(),
       identityKey: payload.identityKey
     };
-    this.sessions.set(payload.sessionId, session);
-    ws.serializeAttachment({ sessionId: payload.sessionId } satisfies AttachmentRecord);
+    ws.serializeAttachment(session satisfies AttachmentRecord);
 
     if (creator) {
       this.roomMeta.creatorJoined = true;
     }
-    this.roomMeta.participantCount = this.sessions.size;
+    this.roomMeta.participantCount = this.connectedSessionIds().length;
     this.roomMeta.lastActivityAt = Date.now();
     await this.ctx.storage.put(ROOM_META_KEY, this.roomMeta);
 
-    const peers = [...this.sessions.values()]
+    const peers = this.connectedSessions()
       .filter((peer) => peer.sessionId !== payload.sessionId)
       .sort((left, right) => left.connectedAt - right.connectedAt)
       .map((peer) => this.describePeer(peer));
@@ -361,7 +366,7 @@ export class RoomDurableObject extends DurableObject<Env> {
       return;
     }
 
-    if (!this.sessions.has(payload.toSessionId)) {
+    if (!this.isConnected(payload.toSessionId)) {
       ws.send(JSON.stringify(errorEvent("peer_missing", "Peer is no longer connected.")));
       return;
     }
@@ -393,7 +398,7 @@ export class RoomDurableObject extends DurableObject<Env> {
     } satisfies PeerDataRelayEvent;
 
     if (payload.toSessionId) {
-      if (!this.sessions.has(payload.toSessionId)) {
+      if (!this.isConnected(payload.toSessionId)) {
         ws.send(JSON.stringify(errorEvent("peer_missing", "Peer is no longer connected.")));
         return;
       }
@@ -415,7 +420,7 @@ export class RoomDurableObject extends DurableObject<Env> {
       return;
     }
     const target = payload.targetSessionId;
-    if (!this.sessions.has(target)) {
+    if (!this.isConnected(target)) {
       ws.send(JSON.stringify(errorEvent("peer_missing", "Participant is no longer connected.")));
       return;
     }
@@ -467,7 +472,7 @@ export class RoomDurableObject extends DurableObject<Env> {
     invite.revokedAt = Date.now();
     this.invites.set(token, invite);
     await this.persistInvites();
-    if (invite.consumedBySessionId && this.sessions.has(invite.consumedBySessionId)) {
+    if (invite.consumedBySessionId && this.isConnected(invite.consumedBySessionId)) {
       await this.disconnectSession(invite.consumedBySessionId, "invite-revoked", "invite revoked");
     }
     return jsonResponse(invite);
@@ -507,7 +512,6 @@ export class RoomDurableObject extends DurableObject<Env> {
     for (const socket of this.ctx.getWebSockets()) {
       socket.close(4000, status);
     }
-    this.sessions.clear();
   }
 
   private async markRoomActivity(): Promise<void> {
@@ -548,7 +552,7 @@ export class RoomDurableObject extends DurableObject<Env> {
       return;
     }
 
-    this.roomMeta.participantCount = this.sessions.size;
+    this.roomMeta.participantCount = this.connectedSessionIds().length;
     await this.ctx.storage.put(ROOM_META_KEY, this.roomMeta);
     this.broadcast({
       type: "presence",
@@ -572,7 +576,6 @@ export class RoomDurableObject extends DurableObject<Env> {
         socket.close(4403, closeReason);
       }
     }
-    this.sessions.delete(targetSessionId);
     this.broadcast({
       type: "peer_left",
       sessionId: targetSessionId
@@ -605,20 +608,37 @@ export class RoomDurableObject extends DurableObject<Env> {
   }
 
   private presenceSnapshot(): PresenceSnapshot {
+    const ids = this.connectedSessionIds();
     return {
-      count: this.connectedSessionIds().length,
-      connectedSessionIds: this.connectedSessionIds()
+      count: ids.length,
+      connectedSessionIds: ids
     };
   }
 
-  private connectedSessionIds(): string[] {
-    return this.ctx
-      .getWebSockets()
-      .map((socket) => (socket.deserializeAttachment() as AttachmentRecord | null)?.sessionId ?? "")
-      .filter(Boolean);
+  // Source of truth for connected participants, derived from live WebSockets so
+  // it survives Durable Object hibernation. Deduplicated by session id.
+  private connectedSessions(): AttachmentRecord[] {
+    const seen = new Set<string>();
+    const sessions: AttachmentRecord[] = [];
+    for (const socket of this.ctx.getWebSockets()) {
+      const attachment = socket.deserializeAttachment() as AttachmentRecord | null;
+      if (attachment?.sessionId && !seen.has(attachment.sessionId)) {
+        seen.add(attachment.sessionId);
+        sessions.push(attachment);
+      }
+    }
+    return sessions;
   }
 
-  private describePeer(peer: SessionRecord): PeerDescriptor {
+  private connectedSessionIds(): string[] {
+    return this.connectedSessions().map((session) => session.sessionId);
+  }
+
+  private isConnected(sessionId: string): boolean {
+    return this.connectedSessions().some((session) => session.sessionId === sessionId);
+  }
+
+  private describePeer(peer: AttachmentRecord): PeerDescriptor {
     return {
       sessionId: peer.sessionId,
       creator: peer.creator,

--- a/durable-objects/room/src/room.ts
+++ b/durable-objects/room/src/room.ts
@@ -290,20 +290,22 @@ export class RoomDurableObject extends DurableObject<Env> {
     if (!creator) {
       const invite = payload.inviteToken ? this.invites.get(payload.inviteToken) : undefined;
       const now = Date.now();
-      if (
-        !invite ||
-        invite.revokedAt ||
-        invite.consumedAt ||
-        invite.expiresAt <= now
-      ) {
-        ws.send(JSON.stringify(errorEvent("invite_required", "A valid one-time invite is required.")));
-        ws.close(4403, "invite required");
-        return;
+      // The session that already consumed this invite may reconnect (e.g. a page
+      // reload) as long as the invite has not been revoked. A brand-new session
+      // must present an invite that is unrevoked, unconsumed, and unexpired.
+      const isReconnectingConsumer =
+        !!invite && !invite.revokedAt && invite.consumedBySessionId === payload.sessionId;
+      if (!isReconnectingConsumer) {
+        if (!invite || invite.revokedAt || invite.consumedAt || invite.expiresAt <= now) {
+          ws.send(JSON.stringify(errorEvent("invite_required", "A valid one-time invite is required.")));
+          ws.close(4403, "invite required");
+          return;
+        }
+        invite.consumedAt = now;
+        invite.consumedBySessionId = payload.sessionId;
+        this.invites.set(invite.token, invite);
+        await this.persistInvites();
       }
-      invite.consumedAt = now;
-      invite.consumedBySessionId = payload.sessionId;
-      this.invites.set(invite.token, invite);
-      await this.persistInvites();
     }
 
     const session: SessionRecord = {

--- a/growth/LAUNCH-KIT.md
+++ b/growth/LAUNCH-KIT.md
@@ -1,0 +1,113 @@
+# elm.chat — Launch Kit
+
+Copy-paste-ready assets for the coordinated launch. Order of operations and timing are in `LAUNCH-RUNBOOK.md`. Everything here leads with the reframe from the growth plan: **elm.chat is a disposable room you share a link to — not a network you have to join.**
+
+---
+
+## 1. Show HN (the anchor — highest value)
+
+**Where:** https://news.ycombinator.com/submit · **When:** Tue–Thu, ~8:00–9:30am ET. Be at your keyboard all day to reply.
+
+**Title options** (pick one; keep it plain — HN punishes hype):
+1. `Show HN: elm.chat – E2E-encrypted chat rooms that self-destruct (Cloudflare DOs)`
+2. `Show HN: Disposable, end-to-end encrypted chat with no accounts and no history`
+3. `Show HN: elm.chat – one-click-deployable ephemeral messenger on Cloudflare`
+
+**URL:** link to the live app (or the GitHub repo — repo tends to draw the HN crowd better for open-source).
+
+**First comment (post immediately after submitting):**
+
+> Hi HN — I built elm.chat because every "private" messenger still ends up as a permanent archive somewhere. This one is designed to leave as little behind as possible:
+>
+> - Rooms are end-to-end encrypted in the browser; the room secret lives in the URL fragment and doesn't normally reach the server.
+> - No accounts, no contact list, no persistent transcript. Rooms self-destruct on a timer or on demand.
+> - Access is via single-use invite links the creator issues and can revoke.
+> - It runs entirely on Cloudflare Workers + a Durable Object per room, so there's no server to babysit — and you can one-click deploy your own instance (Durable Objects get provisioned for you).
+>
+> It's AGPL-3.0, so any modified public instance has to share its source with users — which matters for a tool whose whole pitch is "don't trust the operator more than you must."
+>
+> I'd genuinely value scrutiny on the crypto and the threat model (docs in the repo). It is **not** yet independently audited, and I'm not marketing it to at-risk users until it is. Repo: https://github.com/shawnbure/elm-chat
+>
+> What would you want to see before you'd trust something like this?
+
+**Pre-drafted replies to the 5 questions you'll get:**
+
+- *"How is this different from Signal?"* → Signal is a durable, account-based network for your ongoing relationships. elm.chat is the opposite end: a throwaway room for a single conversation you specifically don't want to persist — closer to a self-destructing PrivateBin with live chat than to a messenger you'd replace Signal with.
+- *"The secret is in the URL fragment — isn't that leaky?"* → The fragment isn't sent in HTTP requests, so it doesn't reach the server in normal use. Risks that remain: browser history, referrer leakage if you're not careful, and shoulder-surfing. Documented in the threat model — feedback welcome.
+- *"What stops abuse if it's anonymous and ephemeral?"* → Cloudflare Turnstile gates room creation; there's a published acceptable-use policy; and by design there's very little to retain. Self-hosters own their instance's moderation. It's a real tension and I don't claim it's solved.
+- *"Is it audited?"* → No. That's the top priority and I'm explicit about not overclaiming until it is. This launch is partly to recruit reviewers.
+- *"Why Cloudflare / vendor lock-in?"* → It lets a solo project run a global real-time app with no servers, and Durable Objects map cleanly to 'one coordinator per room.' It's AGPL and the protocol is documented, so a non-Cloudflare backend is a welcome contribution.
+
+---
+
+## 2. Product Hunt
+
+**Name:** elm.chat
+**Tagline (60 char max):** `Encrypted chat rooms that self-destruct — no signup, no trace`
+**Description:**
+
+> elm.chat is the fastest way to have a conversation that doesn't stick around. Spin up an end-to-end encrypted room, share a single-use invite link, and let it self-destruct on your schedule — minutes, hours, or the moment you're done. No accounts. No contact list. No archive. It's open source (AGPL-3.0) and runs on Cloudflare, so you can one-click deploy your own instance in about a minute.
+
+**First comment (maker):**
+
+> Hey Product Hunt 👋 I kept noticing that "private" chat apps still leave a permanent trail — on a server, in a backup, somewhere. elm.chat is my attempt at the opposite: a room you create, use, and let vanish, with the encryption happening in your browser and the server knowing as little as possible. It's fully open source and self-hostable. I'd love your feedback on where it should go next — especially from anyone who's had to have a conversation they wished they could truly delete afterward.
+
+**Gallery shot list** (reuse `docs/images/`): 1) landing page with the vanish/self-destruct controls, 2) a live room with color-identity chips, 3) the "share invite" flow, 4) the "room self-destructed" screen, 5) a slide reading "no accounts · no archive · no trace."
+
+**Alt platforms to hit the same week:** Peerlist, Uneed, Fazier, Tiny Startups, DevHunt (dev-tool focused). Multi-platform launches convert meaningfully better than PH alone.
+
+---
+
+## 3. Reddit (tailor per sub — never cross-post identical text)
+
+**r/selfhosted** — *Title:* `elm.chat: self-hostable, ephemeral E2E chat on Cloudflare Workers (one-click deploy, AGPL)`
+> Built a disposable encrypted chat that runs entirely on Cloudflare Workers + Durable Objects — no VPS, no database to babysit. One-click "Deploy to Cloudflare" forks it into your account and provisions the Durable Objects automatically. Rooms self-destruct, secrets stay client-side, AGPL-3.0. Repo + threat model in comments. Would love feedback from people who self-host privacy tools.
+
+**r/privacy** — *Title:* `Open-source ephemeral messenger: no accounts, no archive, secret stays in the URL fragment`
+> Sharing an open-source project (not selling anything — it's free and AGPL). It's an E2E-encrypted chat where rooms self-destruct and there's no persistent transcript on the server. I'm explicitly **not** claiming it's audit-grade yet; posting here because this community is the best at finding the holes. Threat model and known-limitations are in the repo. What would you attack first?
+
+**r/opensource** — *Title:* `elm.chat — AGPL ephemeral chat; looking for contributors (crypto review, mobile UX, protocol)`
+> Lead with the "help wanted" areas and good-first-issues; this sub rewards genuine contribution asks over launches.
+
+**r/crypto / r/cryptography** — only post if you want deep protocol scrutiny; lead with the design doc, not the product. Expect (and welcome) harsh feedback.
+
+**Reddit rules of engagement:** read each sub's self-promotion rules first, post as a builder asking for feedback (not an ad), reply to every comment, never link the same text twice.
+
+---
+
+## 4. awesome-list PRs (evergreen backlinks + credibility)
+
+Submit small PRs adding one entry each:
+- `awesome-selfhosted` (Communication → Chat/IRC): `elm.chat - Ephemeral, end-to-end encrypted chat rooms that self-destruct; runs on Cloudflare Workers. (AGPL-3.0)`
+- `awesome-privacy` (Encrypted Messaging or Ephemeral): similar one-liner.
+- PrivacyGuides / privacytools community forum: introduce it as a project seeking review (follow their submission criteria — they require maturity, so frame as "in development, seeking review").
+
+---
+
+## 5. Build-in-public social thread (X / Bluesky / Mastodon)
+
+**Opening post:**
+> I built a chat app designed to forget you.
+> No account. No contact list. No message history on the server.
+> You spin up a room, share a one-time link, and it self-destructs when you're done.
+> Open source, self-hostable in one click. 🧵
+
+**Thread beats:** (2) why permanent chat archives are a liability, (3) how the room secret stays in the URL fragment, (4) the Cloudflare Durable Object architecture in one diagram, (5) the one-click deploy, (6) "it's AGPL so every public fork stays open," (7) "not audited yet — come break it," link.
+
+---
+
+## 6. Press pitch (send AFTER audit progress — see runbook)
+
+**Subject:** `An open-source messenger designed to leave no trace — and to prove it`
+
+> Hi [Name],
+>
+> Most "private" chat apps still keep a copy of your conversation somewhere. I built elm.chat to do the opposite: end-to-end encrypted rooms that self-destruct, with no accounts, no contact graph, and no server-side transcript. It's fully open source under AGPL — meaning even a modified public version has to show its users the code — and anyone can self-host it in one click.
+>
+> [If applicable:] It's currently undergoing independent cryptographic review; happy to share the process and findings.
+>
+> There's a bigger story here about who gets to retain your conversations by default. Happy to walk you through it or get you set up in a room to try it live.
+>
+> Repo: https://github.com/shawnbure/elm-chat
+
+**Targets:** 404 Media, The Verge, TechCrunch, Ars Technica, The Register, plus privacy newsletters (e.g., the ones from EFF, Access Now community). Personalize each — no blast.

--- a/growth/LAUNCH-RUNBOOK.md
+++ b/growth/LAUNCH-RUNBOOK.md
@@ -1,0 +1,40 @@
+# elm.chat — Launch-Day Runbook
+
+A coordinated launch beats a scattered one. This is the hour-by-hour. Assets live in `LAUNCH-KIT.md`.
+
+## T-minus 1 week (prep)
+- [ ] Repo is public and presentable: LICENSE, README with Deploy button + demo GIF, CONTRIBUTING, SECURITY, good-first-issues, ~10 open "good first issue" tickets filed.
+- [ ] Live app tested on mobile + desktop; create → invite → chat → self-destruct all work.
+- [ ] **Load test.** A good Show HN can flood a free-tier Worker. Know your ceiling and have the Cloudflare upgrade path one click away.
+- [ ] Analytics live (Cloudflare Web Analytics or Plausible — cookieless).
+- [ ] Draft all posts from the Launch Kit; line up 5–10 friends who will genuinely try it and comment (not vote-ring — real usage).
+- [ ] Record a 20–30s screen capture: create room → share link → messages vanish. Reuse everywhere.
+
+## T-minus 1 day
+- [ ] Schedule nothing that auto-posts; HN/PH want live humans. Pre-write, post manually.
+- [ ] Clear your calendar for launch day. You must reply to comments within minutes for the first few hours.
+
+## Launch day (all times ET)
+- **8:00** — Submit **Show HN** with the live/repo link. Immediately post the maker's first comment.
+- **8:05** — Post the **Product Hunt** launch + maker comment. Ping your supporters to try it (never "go upvote" — say "we're live, would love your honest take").
+- **8:15** — Post to **r/selfhosted** and **r/privacy** (tailored text, staggered ~30 min apart).
+- **8:30–12:00** — **Reply to every single comment** on HN, PH, and Reddit. This window determines the outcome. Be humble about the audit status; engage the hard questions directly.
+- **10:00** — Post the **build-in-public thread** on X / Bluesky / Mastodon; tag no one, just ship it.
+- **12:00** — Open 2–3 **awesome-list PRs**.
+- **Afternoon** — Keep replying. If traffic spikes, watch Worker limits. Post the demo GIF into threads that are gaining traction.
+- **Evening** — Post a short "thanks + what I learned + what's next" update on the biggest thread that's still live.
+
+## T-plus 1–3 days
+- [ ] Triage the flood of issues/feedback; label, thank, and convert good suggestions into issues.
+- [ ] DM/engage anyone who offered to review the crypto — this is the most valuable outcome.
+- [ ] Publish a short retrospective blog post (also a Show HN-able artifact later).
+
+## What "good" looks like
+- Show HN: front page for a few hours; a wave of GitHub stars/forks and a few self-host deploys.
+- The real win isn't the traffic spike (it fades) — it's the **contributors and reviewers** you recruit and the **backlinks** that feed long-term SEO.
+
+## Do NOT
+- Do not vote-manipulate (rings get penalized/banned on HN and PH).
+- Do not market to activists/journalists as audit-grade yet.
+- Do not post identical text across subreddits.
+- Do not disappear after posting — presence is the whole game.

--- a/growth/blog-how-i-built-elm-chat.md
+++ b/growth/blog-how-i-built-elm-chat.md
@@ -1,0 +1,51 @@
+# How I built an end-to-end encrypted, self-destructing chat on Cloudflare Durable Objects
+
+*Draft for dev.to / Hashnode / personal blog. Aim: rank for "Cloudflare Durable Objects chat" and "ephemeral encrypted chat," and recruit contributors. ~1,200 words. Add your own voice and a diagram before publishing.*
+
+---
+
+Every "private" messenger I've used still ends up storing my conversation somewhere — on a server, in a backup, in a data-broker's lake eventually. I wanted the opposite: a room you create, use, and let vanish, where the infrastructure knows as little as physically possible. That became [elm.chat](https://github.com/shawnbure/elm-chat), and it's open source under AGPL-3.0. Here's how it's built and what I got wrong along the way.
+
+## The design constraint that drove everything
+
+The rule I held myself to: **if a feature improves convenience but expands what the server can retain, log, or reconstruct, it has to justify itself hard.** That single constraint explains almost every architectural decision below.
+
+Concretely, the goals were: no accounts, no contact graph, no persistent server-side transcript, end-to-end encryption, and rooms that self-destruct on purpose.
+
+## Why Cloudflare Workers + Durable Objects
+
+A real-time chat needs somewhere to coordinate live participants. The classic answer is a stateful server (or a Redis pub/sub behind stateless nodes). For a solo, no-budget project that wanted to be globally fast, that's a lot to run and secure.
+
+Cloudflare **Durable Objects** turned out to be an almost perfect fit, because the primitive maps directly onto the domain: **one Durable Object instance per room.** Each room gets a single-threaded coordinator that handles join/presence, relays encrypted events over a WebSocket, enforces the room's policy, and — critically — self-destructs on a timer or on demand. There's no shared database of messages because there's no message database at all. The Worker serves the static client and the API; the Durable Object is the volatile coordination envelope for a single conversation.
+
+The bonus: because it's all Cloudflare, anyone can fork the repo and click "Deploy to Cloudflare" to get their own instance with the Durable Objects provisioned automatically. Self-hosting a real-time app usually means a VPS and a weekend; here it's about a minute.
+
+## Keeping the secret out of the server: the URL fragment
+
+The encryption keys never need to reach the server, so they don't. The room secret lives in the **URL fragment** (`https://elm.chat/c/<room>#<secret>`). Fragments aren't included in HTTP requests, so in normal use the secret stays in the browser. The client uses it to encrypt and decrypt messages locally; the Durable Object only ever relays ciphertext.
+
+This is a deliberately old trick (PrivateBin and others use it) and it comes with honest caveats I document in the threat model: browser history can retain the fragment, referrer headers need care, and a shoulder-surfer or a compromised device sees everything. Client-side crypto protects the transport and the operator — not the endpoints. Being loud about those limits matters more than the marketing.
+
+## Access: single-use invites instead of a forever-link
+
+Early on, a room was one shareable link. That's convenient and wrong: a forwarded or leaked link works forever. Now the creator issues **single-use invite links** that expire and can be revoked, and the creator can remove connected participants. It's a meaningful improvement, though not a cure — if an invite is intercepted before the intended person redeems it, the first redeemer still gets in. Again: documented, not hidden.
+
+## What "self-destruct" actually means
+
+Two independent policies: **message vanish** (messages disappear after minutes/hours/days or never) and **room self-destruct** (the whole room dies after inactivity, a max lifetime, or an explicit "Destroy"). The Durable Object enforces both with alarms and drops everyone when the room ends. The intent is that a room behaves "more like a volatile coordination envelope than a permanent database row."
+
+## Things I got wrong (and fixed, and haven't)
+
+- **White screen of death for peer login** — a race in how peers hydrated room state. Fixed, but it taught me how much of "private" UX is really about graceful failure on flaky mobile networks.
+- **Message-expiry + invite-reload bugs** — expiry and invite consumption interacted in ways I didn't anticipate. Real ephemeral state is harder to reason about than persistent state, because "gone" has to be correct too.
+- **Still open:** transcript sync/dedup when a new participant joins, stronger peer authentication, metadata minimization at the transport layer, and — the big one — **no independent cryptographic audit yet.** I'm explicit about not marketing this to at-risk users until that exists.
+
+## Why AGPL
+
+For a tool whose entire pitch is "don't trust the operator more than you must," the license has to enforce that. AGPL-3.0's Section 13 says: if you run a *modified* version as a network service, you must offer your users the source. So every public deployment — including forks — stays inspectable. That's not incidental to the product; it *is* the product.
+
+## Come break it
+
+The most valuable thing anyone can do is attack the assumptions: review the crypto, poke the threat model, find the metadata leaks. There's a [SECURITY.md](https://github.com/shawnbure/elm-chat/blob/main/SECURITY.md) for private disclosure and a set of [good first issues](https://github.com/shawnbure/elm-chat/blob/main/docs/GOOD-FIRST-ISSUES.md) if you'd rather build. If you've ever wanted a conversation you could truly let disappear, I'd love your help making this one trustworthy enough to be that.
+
+Repo: **https://github.com/shawnbure/elm-chat** · Try it live and deploy your own from the README's one-click button.

--- a/growth/content/content-2026-07-02.md
+++ b/growth/content/content-2026-07-02.md
@@ -1,0 +1,130 @@
+# elm.chat weekly content — 2026-07-02
+
+**This week's theme:** the journalist ↔ source wedge (secure tip channel). New SEO angle not covered in `growth/seo/` (which has: anonymous feedback link, self-destructing chat, send a password securely).
+
+**Autonomous-run notes:** First entry in `growth/content/`. Chose the "how journalists share info with sources" angle from the candidate list because it's a high-intent wedge use case and doesn't overlap existing SEO drafts. Nothing here should be treated as a security guarantee — copy stays within documented limits (not audited; endpoints defeat any tool).
+
+---
+
+## 1. SEO article draft (~700 words)
+
+---
+title: "How Journalists and Sources Share Information Securely (Without Leaving a Trail)"
+description: "A source wants to share something sensitive. Here's how reporters and tipsters can talk and exchange files privately, with nothing left sitting on a server afterward."
+target_keywords: ["how to share information with a journalist securely", "secure way to leak documents", "how journalists protect sources", "anonymous tip to a reporter", "secure channel for sources", "send documents to a journalist anonymously"]
+canonical_cta: "https://elm.chat"
+---
+
+# How Journalists and Sources Share Information Securely (Without Leaving a Trail)
+
+The riskiest moment in most tips isn't the reporting — it's first contact. A source emails a Gmail account, DMs a reporter on a platform tied to their real name, or texts a photo of a document. Each of those leaves a durable record on at least two devices and one or more company servers, and each ties a person to a story they may have real reasons to stay separated from.
+
+If you're a reporter setting up a way for people to reach you, or a source deciding how to make contact, the goal is the same: **exchange what's needed and leave as little behind as possible.**
+
+## Why the obvious channels are the risky ones
+
+- **Email and DMs persist.** The message lives in both accounts and their backups indefinitely, and both can be searched, subpoenaed, or breached later.
+- **They're identity-bound.** A work email, a phone number, or a social handle points straight back to a named person.
+- **Attachments carry metadata.** Photos and office documents often embed device IDs, GPS, author names, and edit history that survive forwarding.
+- **"Delete" rarely means gone.** Removing a message from your view doesn't remove it from the other side or from server storage.
+
+Established newsrooms run tools like SecureDrop for exactly this reason. Those are excellent and, for genuinely high-stakes leaks, worth using. But most reporters don't run one, and most first contacts happen on whatever's convenient — which is where the exposure creeps in.
+
+## The pattern: a disposable room, not a permanent thread
+
+For the common case — a quick, sensitive exchange where neither side wants a lasting record — an ephemeral, end-to-end encrypted room fits the job:
+
+- The reporter opens a room and shares a link (in a bio, a story footer, or a one-off message).
+- The source joins with **no account and no name** — just an anonymous identity.
+- Both sides talk, share files, and confirm what's needed.
+- The room **self-destructs** on a timer or on demand, so there's no thread to surface later.
+
+Because there's no login, the conversation isn't anchored to either person's identity, and because the room is destroyed, there's no server-side transcript waiting to be found.
+
+### How to do it with elm.chat
+
+1. Open [elm.chat](https://elm.chat) and create a room. Set messages to vanish quickly and the room to self-destruct after it's idle.
+2. Share a **single-use invite link** with your source (or publish a fresh one when you expect contact). The reporter can revoke it and remove participants.
+3. Talk and exchange files — content is end-to-end encrypted in the browser, and files stream encrypted between participants.
+4. Hit **Destroy** or let it expire. No transcript is stored server-side.
+
+The room secret stays in your browser's URL fragment and doesn't normally reach the server, so the operator only ever relays ciphertext. It's open source (AGPL-3.0) and [self-hostable](https://github.com/shawnbure/elm-chat), so a newsroom can run its own instance and not take anyone's word for how it behaves.
+
+## Honest limits — read these before you rely on it
+
+- **elm.chat is not yet independently audited.** For life-or-liberty leaks, use a channel your threat model already trusts (e.g., SecureDrop via Tor) rather than something un-audited.
+- **The endpoints are always the weak point.** A screenshot, a compromised phone, or someone reading over a shoulder defeats any tool.
+- **Metadata never fully disappears.** Network-level traces (who connected, when) exist to some degree everywhere.
+- **Strip file metadata yourself** before sharing, and avoid identifying details in the conversation.
+- A source on their own device and network still carries whatever risk that device and network carry.
+
+Used within those limits, a disposable encrypted room lowers the amount that can be retained and reconstructed after a sensitive exchange. It won't make anyone invisible — but for a first contact you don't want to become a permanent record, it's a sensible default.
+
+---
+
+> **Setting up a private tip channel?** [Open a self-destructing room on elm.chat →](https://elm.chat) No signup, encrypted in your browser, gone when you're done.
+
+**Channel:** publish to the elm.chat blog / `growth/seo/` as `journalists-share-with-sources.md`; syndicate a trimmed version to dev.to and a relevant infosec/journalism subreddit where self-promo is allowed.
+
+---
+
+## 2. Short-form video scripts (15–30s each)
+
+### Script A — "The email that never dies" (~20s)
+**Hook (0–3s):** "Your source just emailed you a leaked document. It's now in four places forever."
+**Beat 1:** Show an inbox — the email sits there. Text: *your account.*
+**Beat 2:** Cut to their sent folder. Text: *their account.*
+**Beat 3:** Cut to two greyed server icons. Text: *two backups you'll never see.*
+**Beat 4:** Cut to an elm.chat room; a message and a file appear, then dissolve into particles as the room screen fades to "Room destroyed."
+**On-screen text (end card):** "A room you share once, then it's gone. elm.chat"
+**Voiceover close:** "Talk, share the file, let the room self-destruct. Not audited yet — read the limits."
+
+### Script B — "No name, no account, no trace" (~15s)
+**Hook (0–3s):** "How do you talk to someone without either of you leaving a record?"
+**Beat 1:** A link is generated and copied. Text: *one link.*
+**Beat 2:** Two anonymous color chips appear in a room — no usernames. Text: *no accounts.*
+**Beat 3:** Messages type out, then vanish one by one. Text: *nothing kept.*
+**On-screen text (end card):** "Encrypted in your browser. Open source. elm.chat"
+**Voiceover close:** "A disposable room, not a network you join."
+
+### Script C — "Watch it disappear" (~25s, satisfying-dissolve focus)
+**Hook (0–3s):** "This is what 'delete' should actually look like."
+**Beat 1:** A full conversation on screen — several messages, a shared photo.
+**Beat 2:** A countdown timer ticks: 3… 2… 1.
+**Beat 3:** Every message and the photo dissolve/shatter in sequence, top to bottom.
+**Beat 4:** The empty room collapses into a single line: "Room destroyed. Nothing was saved."
+**On-screen text (end card):** "elm.chat — self-destructing, encrypted, no signup."
+**Voiceover close:** "Real ephemerality you can watch happen. A screenshot still beats it — so trust the room, not the magic."
+
+**Channel:** post all three to TikTok, Instagram Reels, and YouTube Shorts. Lead the week with Script C (most visually satisfying); Script A works well as a paid-boost candidate later.
+
+---
+
+## 3. Build-in-public thread (5–7 posts) — facet: the threat model & saying "no" to features
+
+**Channel:** X, Bluesky, and Mastodon (post natively to each; don't cross-link). Facet rotates each week — this week is the discipline of *not* shipping convenient features. Next weeks: architecture (Durable Objects), the AGPL choice, a milestone, contributor asks.
+
+**1/**
+Building a "private" chat teaches you fast that most privacy leaks aren't hacks — they're features. Convenient ones. Here's the rule I hold elm.chat to, and the stuff I've said no to because of it. 🧵
+
+**2/**
+The rule: if a feature improves convenience but expands what the server can retain, log, or reconstruct, it has to justify itself *hard*. Almost every design decision falls out of that one sentence.
+
+**3/**
+No accounts. Tempting to add — accounts give you history, notifications, a contact list. But an account is a permanent identity anchor for a tool whose whole point is *not* leaving a trace. So: anonymous color identities, and nothing to log in to.
+
+**4/**
+No server-side transcript. There's genuinely no message database. Each room is one Cloudflare Durable Object that relays ciphertext and then self-destructs. "Gone" is only trustworthy if there was never a copy to begin with.
+
+**5/**
+The secret stays out of the server. Room keys live in the URL fragment, which isn't sent in HTTP requests — so the operator only ever sees ciphertext. Old trick (PrivateBin did it), real caveats: browser history and referrers need care. Documented, not hidden.
+
+**6/**
+What I *haven't* solved, out loud: no independent crypto audit yet, peer authentication could be stronger, and transport metadata still exists. I won't market this to at-risk users until the audit exists. Overclaiming security is its own harm.
+
+**7/**
+If you like breaking assumptions: review the crypto, poke the threat model, find a metadata leak. AGPL-3.0, one-click deployable on Cloudflare. Repo + SECURITY.md → https://github.com/shawnbure/elm-chat · try it: https://elm.chat
+
+---
+
+*Reminder for the operator: verify the app's current feature set (invite revocation, file streaming, vanish/self-destruct controls) still matches this copy before publishing, and never state or imply the audit is complete.*

--- a/growth/digests/digest-2026-07-02.md
+++ b/growth/digests/digest-2026-07-02.md
@@ -1,0 +1,92 @@
+# elm.chat — Weekly Growth Digest
+
+**Date:** 2026-07-02
+**Analyst:** automated weekly run
+
+---
+
+## TL;DR
+
+Still pre-launch in every measurable way: **0 mentions, 0 stars, 0 forks, and no commits since April 13.** The market kept moving without you — X Chat (April) and Germ/Bluesky (Feb) both shipped E2E ephemeral messaging, and the one-time-secret category (your #1 wedge) is crowded and active. Nothing has changed in elm.chat's numbers since the last run. The single highest-leverage move remains shipping Phase 0 and getting the repo launch-worthy — you can't feed any loop with a repo that has no LICENSE, no Deploy button, and no invite footer.
+
+---
+
+## 1. Mentions watch
+
+**No new mentions of "elm.chat" or "elm chat" found this week** across Hacker News, Reddit, X/Bluesky, blogs, or news.
+
+Searches surfaced only unrelated namesakes: `elm-messenger/Messenger` (an Elm game engine), `madsbuch/elm-chat` (an Elm demo app), and a 2015 Show HN for a different disposable-chat tool. There is no public footprint for the product yet — expected, since no launch has happened. Nothing needs a reply.
+
+*Implication: the "mentions watch" only starts producing signal after the Phase 1 launch spike. Until then this section will keep reading zero.*
+
+---
+
+## 2. Trend & competitor watch
+
+The category is heating up at the top and staying crowded at the wedge. Four items worth noting:
+
+1. **X Chat (launched ~April 28, 2026)** — E2E encrypted, blocks screenshots, disappearing messages, large file transfer, no ads, no tracking. This is the most direct threat to the "disappearing messages" framing, but it's account-bound and locked to the X platform. elm.chat's edge is the opposite: **no account, no app, just a link** — bring-your-own-counterparty. Lean into that contrast.
+
+2. **Germ + Bluesky (Feb 2026)** — first private messenger launching natively inside Bluesky, using IETF's MLS standard over ATProto. Signals that E2E is becoming table-stakes and standards-based. Doesn't compete on ephemerality/disposability, but raises the bar on crypto credibility — reinforces why your public crypto review (Phase 2) matters before any at-risk-user marketing.
+
+3. **One-Time Secret** completed its EU invites rollout (**June 15, 2026**), finishing across all five regions. Your #1 wedge ("send me a password/secret through a room that self-destructs") competes directly here — but they do *one-way secret drops*, not *live two-way chat + file transfer*. That differentiator is real and under-exploited.
+
+4. **Crowded wedge, still winnable.** password.link, Password Pusher, 1time.io, Yopass, Bitwarden Send, 1ty.me all fight over "send password securely." High evergreen search demand = the SEO loop (Loop 3) has real oxygen — but you win the click by offering *back-and-forth*, which none of them do.
+
+**Positioning takeaway:** the big players own "disappearing messages inside our network." Nobody owns **"a link that opens a private, self-destructing room with a stranger, no account."** That's still open. Keep saying "disposable rooms" / "self-destructing chat."
+
+---
+
+## 3. GitHub health
+
+Source: `https://api.github.com/repos/shawnbure/elm-chat`
+
+| Metric | Value |
+|---|---|
+| Stargazers | **0** |
+| Forks | **0** |
+| Open issues | **0** |
+| Watchers | 0 |
+| Language | TypeScript |
+| License | **none** ⚠️ |
+| Last push | **2026-04-13** |
+| Created | 2026-04-09 |
+
+**No change since last run.** Repo has been dormant for ~11 weeks. Two red flags block the growth plan directly: there is still **no LICENSE** (which legally blocks the forking/contributing that Loops 2 is built on), and there's no `description`, `homepage`, or topics set on the repo — free metadata that costs nothing and helps discovery. Nothing to infer about "community tone" yet because there is no community activity to read.
+
+---
+
+## 4. K-factor / funnel check
+
+No analytics source is connected (no Cloudflare Web Analytics or Plausible detected). **No analytics numbers are being fabricated.**
+
+The four numbers that matter most, and where to pull them manually until analytics is wired up:
+
+1. **Rooms created / week** — top-line health. Instrument on the Worker (aggregate count only, no content). *Not available yet.*
+2. **Invite-link click-through** — did the room reach a second person? = Loop 1 strength. Pull from invite-landing-page hits. *Not available yet.*
+3. **"Make your own" CTA clicks** on invite pages — the viral conversion event. *Requires the invite footer to exist first (it doesn't).*
+4. **GitHub stars / forks / self-host deploys** — Loop 2. *Currently 0 / 0 / 0.*
+
+**K-factor = new creators generated per existing creator. Target > 1.0. Currently uncomputable (numerator and denominator both ~0).**
+
+To make this section useful next week: connect **Cloudflare Web Analytics** (cookieless, on-brand, free) and add a single aggregate "rooms created" counter. Without at least those two, the funnel stays dark.
+
+---
+
+## 5. This week's one move
+
+**Ship Phase 0 — make the repo launch-worthy — starting with the LICENSE + the invite-loop footer.**
+
+Rationale tied to loop momentum: none of the three loops has momentum yet because none of them can physically run. But the invite loop (Loop 1) is the cheapest to arm and, per the growth plan, "the single most important growth change you can ship" — one line on the invite landing page: *"This secure room was created with elm.chat — make your own free, no signup."* Pair it with the two things that unblock everything else and cost an afternoon:
+
+- **Add a LICENSE** (AGPL-3.0 for a trust-sensitive privacy tool, or MIT for max adoption — your call, but the *absence* is actively blocking Loop 2).
+- **Ship the invite-page footer** (arms Loop 1).
+- **Set repo description + homepage (`https://elm.chat`) + topics**, and connect **Cloudflare Web Analytics** so next week's funnel section has real data.
+
+Do not pursue launch channels (Show HN, Reddit, Product Hunt) until these land — a launch that sends traffic to an unlicensed, un-instrumented repo with no "make your own" hook wastes your one first impression.
+
+*Guardrail: don't market to activists/journalists or claim any completed audit — the crypto review hasn't started. Overclaiming security is the fastest way to lose the privacy community permanently.*
+
+---
+
+*Sources: GitHub API for shawnbure/elm-chat; web searches on ephemeral/self-destructing messaging, one-time-secret tools, and private-messaging launches (X Chat, Germ/Bluesky, One-Time Secret). No elm.chat mentions found this week.*

--- a/growth/seo/anonymous-feedback-link.md
+++ b/growth/seo/anonymous-feedback-link.md
@@ -1,0 +1,58 @@
+---
+title: "How to Collect Truly Anonymous Feedback (a Link You Can Share Anywhere)"
+description: "Want honest, anonymous feedback from a team, class, or community? Here's how to create an anonymous feedback link that keeps responses private and leaves no permanent record."
+target_keywords: ["anonymous feedback link", "collect anonymous feedback", "anonymous message link", "anonymous q and a", "anonymous suggestion box online", "get honest feedback anonymously"]
+canonical_cta: "https://elm.chat"
+---
+
+# How to Collect Truly Anonymous Feedback (a Link You Can Share Anywhere)
+
+Honest feedback only shows up when people believe they can't be traced. If you're a manager, professor, club lead, or community organizer, the quality of what you learn depends entirely on whether respondents trust the channel. Most "anonymous" forms quietly log emails, IPs, or timestamps — and people can tell.
+
+Here's how to set up feedback that's actually anonymous, and store as little as possible afterward.
+
+## Why most "anonymous" forms aren't
+
+- **They capture metadata** — IP address, timestamp, sometimes a signed-in account — even when they don't ask for a name.
+- **Responses persist forever** in a spreadsheet or database, which becomes a liability if it leaks.
+- **People assume they're identifiable** and self-censor, so you get polite mush instead of the truth.
+
+If your goal is candor, you want a channel where there's genuinely nothing to trace and nothing to retain long-term.
+
+## The pattern: a shared room, not a form
+
+An ephemeral, no-account chat room works surprisingly well as an anonymous feedback or Q&A channel:
+
+- You (the creator) open a room and get a link.
+- You drop the link wherever your audience is — a group chat, a slide at the end of a talk, a Slack channel, a printed QR code on a wall.
+- People join with **no account and no name** — just an anonymous color identity.
+- They say what they actually think.
+- The room self-destructs on your schedule, so there's no permanent archive to leak or subpoena.
+
+Because there's no login, no one — including you — can tie a comment back to a person. That's the point.
+
+### How to do it with elm.chat
+
+1. Open [elm.chat](https://elm.chat), create a room, and set message/room lifetimes to match your session (e.g., open for the duration of a meeting, then self-destruct).
+2. Share the room link or a **QR code** with your group. For a wider audience, share the join link directly.
+3. Participants appear as anonymous color chips — no usernames, no accounts.
+4. Collect the honest input; when you're done, hit **Destroy** or let it expire.
+
+Everything is end-to-end encrypted in the browser, the room secret stays client-side, and there's no server-side transcript. It's open source (AGPL-3.0) and [self-hostable](https://github.com/shawnbure/elm-chat) if your organization wants to run its own instance.
+
+## Great use cases
+
+- **Classrooms:** mid-semester course feedback, anonymous Q&A during a lecture, sensitive topics students won't raise by name.
+- **Teams:** retro input, "what's not working," feedback for a manager that people won't put in a named form.
+- **Clubs & communities:** suggestions, confessions, event ideas.
+- **Events:** live audience questions without the awkward hand-raise.
+
+## Keep it genuinely safe
+
+- Keep the room open only as long as you need it, then destroy it.
+- Don't ask follow-up questions that could re-identify someone ("the person who mentioned X…").
+- Remember participants should avoid including identifying details themselves.
+
+---
+
+> **Want honest answers?** [Create an anonymous feedback room on elm.chat →](https://elm.chat) Share the link, collect candid input, let it vanish. No signup.

--- a/growth/seo/self-destructing-chat.md
+++ b/growth/seo/self-destructing-chat.md
@@ -1,0 +1,53 @@
+---
+title: "Self-Destructing Chat: How Disappearing Messages Actually Work (and Which Are Real)"
+description: "Not all 'disappearing messages' really disappear. Here's what self-destructing chat means, where the catches are, and how to have a conversation that leaves no trace."
+target_keywords: ["self destructing chat", "disappearing messages", "chat that deletes itself", "temporary chat room", "anonymous disappearing chat", "no history chat app"]
+canonical_cta: "https://elm.chat"
+---
+
+# Self-Destructing Chat: How Disappearing Messages Actually Work
+
+"Disappearing messages" is now a checkbox in most chat apps. But there's a big gap between a message vanishing *from your screen* and a conversation that genuinely leaves no trace. If your reason for wanting messages to disappear is real — a sensitive personal matter, a source, a one-off coordination — that gap matters.
+
+## What "self-destructing" should actually mean
+
+A truly ephemeral conversation has several independent properties. Most apps give you one or two:
+
+- **Client deletion** — the message disappears from the app UI. (Common.)
+- **Server deletion** — no copy remains on the provider's servers or backups. (Rare, and hard to verify.)
+- **End-to-end encryption** — the provider couldn't read it even while it existed. (Some apps.)
+- **No account / no identity** — the conversation isn't tied to a phone number or profile. (Very rare.)
+- **No metadata trail** — who talked to whom, when, is minimized. (Almost never.)
+
+The catch with most mainstream "disappearing messages": the message leaves *your* view, but you're trusting a company's server-side behavior you can't inspect, and your identity is attached the whole time. And of course, **any tool can be defeated by a screenshot or a compromised device** — that's true everywhere and worth stating plainly.
+
+## Two kinds of self-destruct, and why you want both
+
+1. **Message vanish** — individual messages delete after a set time (minutes, hours, days).
+2. **Room self-destruct** — the entire conversation space is destroyed after inactivity, a maximum lifetime, or on demand.
+
+You want both, because message-level expiry still leaves the *container* — participants, timing, the fact the conversation happened — around. Destroying the room closes that gap.
+
+## How to have a conversation that actually disappears
+
+The most trustworthy setup is one where you don't have to take the operator's word for it:
+
+- **Encryption happens in your browser**, so the server only ever sees ciphertext.
+- **The room self-destructs** and there's no persistent transcript stored server-side.
+- **No account** ties the conversation to you.
+- **The code is open source**, so the claims are inspectable — and you can run your own copy.
+
+[elm.chat](https://elm.chat) is built exactly around this. You create a room, choose how fast messages vanish and when the room self-destructs, and share a single-use invite link. Messages are end-to-end encrypted in the browser; the room secret stays in the URL fragment and doesn't normally reach the server; there's no account and no server-side archive. When you're done, the room dies. It's AGPL-3.0 and [self-hostable in one click](https://github.com/shawnbure/elm-chat), so you don't have to trust anyone's marketing — you can read the code.
+
+## Honest limitations (any tool that hides these is lying)
+
+- Screenshots, clipboard history, and malware on either device expose everything.
+- If someone forwards plaintext or the room link after joining, the protocol can't stop human leakage.
+- Transport-level metadata always exists to some degree.
+- elm.chat specifically is **not yet independently audited** — treat it accordingly for high-stakes use.
+
+Ephemeral chat reduces what can be retained and reconstructed later. It doesn't make you invisible. Used with those limits in mind, it's the right tool for conversations that shouldn't become permanent records.
+
+---
+
+> **Want a conversation that deletes itself?** [Spin up a self-destructing room on elm.chat →](https://elm.chat) Free, no signup, gone when you're done.

--- a/growth/seo/send-a-password-securely.md
+++ b/growth/seo/send-a-password-securely.md
@@ -1,0 +1,55 @@
+---
+title: "How to Send a Password Securely (Without Emailing or Texting It)"
+description: "Emailing or texting a password leaves it sitting in inboxes and chat logs forever. Here's how to share a password, API key, or secret so it disappears after it's read."
+target_keywords: ["send password securely", "share password safely", "how to send a password", "send api key securely", "one time secret"]
+canonical_cta: "https://elm.chat"
+---
+
+# How to Send a Password Securely (Without Emailing or Texting It)
+
+You need to give someone a password, an API key, a Wi-Fi code, a recovery phrase, or a client's login. The tempting options — email, Slack, iMessage, a text — all share one flaw: **the secret keeps existing** in inboxes, chat histories, backups, and screenshots long after the moment has passed. Anyone who later accesses that account or device can read it.
+
+Here's how to do it properly, and why "it disappears after reading" is the feature that matters.
+
+## Why email and text are the wrong tools
+
+- **They persist.** A password sent over email or chat lives in at least two accounts indefinitely, plus server backups.
+- **They're searchable.** "password" in an inbox search is a goldmine for anyone who gets in.
+- **They're forwardable.** One thread gets forwarded and your secret spreads silently.
+- **They're often unencrypted at rest** on the provider's servers.
+
+Rotating the password afterward helps, but people rarely do, and some secrets (a recovery phrase, an SSN) can't simply be rotated.
+
+## The right pattern: share it through something ephemeral
+
+The safe pattern has three properties:
+
+1. **End-to-end encrypted** — the service transporting the secret can't read it.
+2. **Self-destructing** — the secret is destroyed after it's read or after a short timer.
+3. **No account required** — you shouldn't have to create a profile just to hand someone a string once.
+
+Classic "one-time secret" tools (PrivateBin, One-Time Secret, Yopass) do the one-way version well: you paste a secret, get a link, and it burns after one view.
+
+## When you need a conversation, not just a drop
+
+Sometimes handing over a secret involves back-and-forth: "which environment is this for?", "it's not working," "here's a second key." A one-way paste can't do that. That's where an **ephemeral, end-to-end encrypted chat room** fits: you and the recipient can talk, share the secret and any files, confirm it worked — and then the whole room self-destructs, leaving nothing behind.
+
+### How to do it with elm.chat
+
+1. Open [elm.chat](https://elm.chat) and create a room. Set messages to vanish (say, 15 minutes) and the room to self-destruct after it's idle.
+2. Send the recipient a **single-use invite link** — one link, one person, and you can revoke it.
+3. Share the password (and any files — they're encrypted and stream peer-to-peer). Confirm it worked.
+4. Hit **Destroy**, or just let the room expire. No transcript is left on the server.
+
+The room secret stays in your browser's URL fragment and doesn't normally reach the server, message content is encrypted in the browser, and there's no account tying the exchange to your identity. It's open source (AGPL-3.0) and you can even [self-host your own instance](https://github.com/shawnbure/elm-chat) if you want full control.
+
+## A few habits that matter regardless of tool
+
+- Share the secret only when the recipient is ready to use it, then destroy the room.
+- Prefer single-use links over reusable ones.
+- Rotate credentials after sharing when you can.
+- Remember that a screenshot or a compromised device defeats any tool — the endpoints are always the weak point.
+
+---
+
+> **Need to hand off a password right now?** [Create a private, self-destructing room on elm.chat →](https://elm.chat) No signup. It vanishes when you're done.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
         "workers/*",
         "packages/*",
         "durable-objects/*"
-      ]
+      ],
+      "devDependencies": {
+        "concurrently": "^9.1.2"
+      }
     },
     "apps/web": {
       "name": "@elm-chat/web",
@@ -1965,6 +1968,32 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -2040,6 +2069,112 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.4",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2102,6 +2237,13 @@
       "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -2206,6 +2348,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/js-tokens": {
@@ -2409,6 +2581,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -2452,6 +2634,16 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/scheduler": {
@@ -2528,6 +2720,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2536,6 +2741,34 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -2568,13 +2801,22 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -3256,6 +3498,24 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -3278,12 +3538,51 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "scripts": {
     "build": "npm run build --workspace @elm-chat/web && npm run build --workspace @elm-chat/api",
     "typecheck": "npm run typecheck --workspace @elm-chat/shared && npm run typecheck --workspace @elm-chat/crypto && npm run typecheck --workspace @elm-chat/web && npm run typecheck --workspace @elm-chat/api",
+    "dev": "concurrently -k -n api,web -c blue,green \"npm:dev:api\" \"npm:dev:web\"",
     "dev:web": "npm run dev --workspace @elm-chat/web",
     "dev:api": "npm run dev --workspace @elm-chat/api"
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typecheck": "npm run typecheck --workspace @elm-chat/shared && npm run typecheck --workspace @elm-chat/crypto && npm run typecheck --workspace @elm-chat/web && npm run typecheck --workspace @elm-chat/api",
     "dev": "concurrently -k -n api,web -c blue,green \"npm:dev:api\" \"npm:dev:web\"",
     "dev:web": "npm run dev --workspace @elm-chat/web",
-    "dev:api": "npm run dev --workspace @elm-chat/api"
+    "dev:api": "npm run dev --workspace @elm-chat/api",
+    "deploy": "npm run build --workspace @elm-chat/web && npm run deploy --workspace @elm-chat/api"
   },
   "devDependencies": {
     "concurrently": "^9.1.2"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,7 +16,10 @@ export type IceServer = {
 
 export const DEFAULT_STUN_ICE_SERVERS: IceServer[] = [{ urls: ["stun:stun.cloudflare.com:3478"] }];
 export const MAX_FILE_BYTES = 25 * 1024 * 1024;
-export const FILE_CHUNK_BYTES = 16 * 1024;
+// 64 KiB of plaintext per chunk. Base64 (~87 KiB) plus the JSON envelope stays
+// well under the Cloudflare Workers ~1 MiB WebSocket message limit, while
+// keeping the chunk count for a 25 MiB file in the low hundreds.
+export const FILE_CHUNK_BYTES = 64 * 1024;
 
 export type RoomStatus = "open" | "expired" | "destroyed";
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,13 +8,6 @@ export const DEFAULT_MAX_ROOM_AGE_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_DISAPPEAR_AFTER_READ_SECONDS = 7 * 60;
 export const MAX_CONNECTIONS_PER_ROOM = 16;
 export const MAX_TRANSCRIPT_SYNC_MESSAGES = 200;
-export type IceServer = {
-  urls: string[];
-  username?: string;
-  credential?: string;
-};
-
-export const DEFAULT_STUN_ICE_SERVERS: IceServer[] = [{ urls: ["stun:stun.cloudflare.com:3478"] }];
 export const MAX_FILE_BYTES = 25 * 1024 * 1024;
 // 64 KiB of plaintext per chunk. Base64 (~87 KiB) plus the JSON envelope stays
 // well under the Cloudflare Workers ~1 MiB WebSocket message limit, while
@@ -40,11 +33,6 @@ export interface CreateRoomResponse {
   maxAgeMs: number | null;
   disappearAfterReadSeconds: number | null;
   creatorToken: string;
-}
-
-export interface TurnCredentialsResponse {
-  iceServers: IceServer[];
-  ttlSeconds: number;
 }
 
 export interface RoomMetadata {
@@ -83,28 +71,12 @@ export interface PresenceSnapshot {
   connectedSessionIds: string[];
 }
 
-export type PeerSignal =
-  | { type: "offer"; sdp: string }
-  | { type: "answer"; sdp: string }
-  | {
-      type: "ice";
-      candidate: string;
-      sdpMid?: string | null;
-      sdpMLineIndex?: number | null;
-    };
-
 export interface JoinPayload {
   type: "join";
   sessionId: string;
   identityKey: string;
   creatorToken?: string;
   inviteToken?: string;
-}
-
-export interface SignalPayload {
-  type: "signal";
-  toSessionId: string;
-  signal: PeerSignal;
 }
 
 export interface PeerDataRelayPayload {
@@ -130,7 +102,6 @@ export interface KickParticipantPayload {
 
 export type ClientEvent =
   | JoinPayload
-  | SignalPayload
   | PeerDataRelayPayload
   | KickParticipantPayload
   | DestroyPayload
@@ -158,12 +129,6 @@ export interface PeerJoinedEvent {
 export interface PeerLeftEvent {
   type: "peer_left";
   sessionId: string;
-}
-
-export interface SignalEvent {
-  type: "signal";
-  fromSessionId: string;
-  signal: PeerSignal;
 }
 
 export interface PeerDataRelayEvent {
@@ -196,7 +161,6 @@ export type ServerEvent =
   | PresenceEvent
   | PeerJoinedEvent
   | PeerLeftEvent
-  | SignalEvent
   | PeerDataRelayEvent
   | ParticipantKickedEvent
   | RoomStateEvent

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "wrangler deploy --dry-run",
     "dev": "wrangler dev",
+    "deploy": "CLOUDFLARE_ACCOUNT_ID=\"${ELM_CHAT_CLOUDFLARE_ACCOUNT_ID:-$CLOUDFLARE_ACCOUNT_ID}\" wrangler deploy",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   }
 }

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -1,11 +1,9 @@
 import {
-  DEFAULT_STUN_ICE_SERVERS,
   DEFAULT_DISAPPEAR_AFTER_READ_SECONDS,
   DEFAULT_INACTIVITY_TIMEOUT_MS,
   ROOM_ID_BYTES,
   type CreateRoomRequest,
-  type CreateRoomResponse,
-  type TurnCredentialsResponse
+  type CreateRoomResponse
 } from "@elm-chat/shared";
 import { RoomDurableObject } from "../../../durable-objects/room/src/room";
 
@@ -14,8 +12,6 @@ export { RoomDurableObject };
 type Env = {
   ASSETS: Fetcher;
   ROOM_OBJECT: DurableObjectNamespace<RoomDurableObject>;
-  TURN_SECRET?: string;
-  TURN_URLS?: string;
   TURNSTILE_SECRET?: string;
 };
 
@@ -63,28 +59,6 @@ function randomRoomId(): string {
 
 function randomToken(): string {
   return base64Url(crypto.getRandomValues(new Uint8Array(32)));
-}
-
-function parseTurnUrls(value?: string): string[] {
-  if (!value) {
-    return [];
-  }
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-async function hmacSha1Base64(secret: string, message: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-1" },
-    false,
-    ["sign"]
-  );
-  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
-  return btoa(String.fromCharCode(...new Uint8Array(signature)));
 }
 
 async function safeJson<T>(request: Request): Promise<T> {
@@ -216,36 +190,11 @@ async function handleRevokeInvite(request: Request, roomId: string, env: Env): P
   });
 }
 
-async function handleTurnCredentials(env: Env): Promise<Response> {
-  const ttlSeconds = 600;
-  const iceServers = [...DEFAULT_STUN_ICE_SERVERS];
-  const turnUrls = parseTurnUrls(env.TURN_URLS);
-
-  if (env.TURN_SECRET && turnUrls.length > 0) {
-    const username = `${Math.floor(Date.now() / 1000) + ttlSeconds}:${crypto.randomUUID()}`;
-    const credential = await hmacSha1Base64(env.TURN_SECRET, username);
-    iceServers.push({
-      urls: turnUrls,
-      username,
-      credential
-    });
-  }
-
-  return json({
-    iceServers,
-    ttlSeconds
-  } satisfies TurnCredentialsResponse);
-}
-
 function routeApi(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
 
   if (request.method === "POST" && url.pathname === "/api/rooms") {
     return handleCreateRoom(request, env);
-  }
-
-  if (request.method === "GET" && url.pathname === "/api/turn-credentials") {
-    return handleTurnCredentials(env);
   }
 
   const revokeMatch = url.pathname.match(/^\/api\/rooms\/([^/]+)\/invites\/revoke$/);

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -16,6 +16,7 @@ type Env = {
   ROOM_OBJECT: DurableObjectNamespace<RoomDurableObject>;
   TURN_SECRET?: string;
   TURN_URLS?: string;
+  TURNSTILE_SECRET?: string;
 };
 
 function json(payload: unknown, status = 200): Response {
@@ -95,10 +96,51 @@ function buildRoomUrl(request: Request, roomId: string): string {
   return `${url.origin}/c/${roomId}`;
 }
 
+async function verifyTurnstile(
+  secret: string,
+  token: string | undefined,
+  remoteIp: string | null
+): Promise<boolean> {
+  if (!token) {
+    return false;
+  }
+  const form = new FormData();
+  form.append("secret", secret);
+  form.append("response", token);
+  if (remoteIp) {
+    form.append("remoteip", remoteIp);
+  }
+  try {
+    const response = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      body: form
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const outcome = (await response.json()) as { success?: boolean };
+    return outcome.success === true;
+  } catch {
+    return false;
+  }
+}
+
 async function handleCreateRoom(request: Request, env: Env): Promise<Response> {
   const body = await safeJson<CreateRoomRequest>(request).catch(() => ({} as CreateRoomRequest));
 
-  // Abuse-prevention hook: verify Turnstile token here.
+  // Abuse prevention: when a Turnstile secret is configured, require a valid
+  // token. Without a secret (e.g. local dev) creation stays open.
+  if (env.TURNSTILE_SECRET) {
+    const passed = await verifyTurnstile(
+      env.TURNSTILE_SECRET,
+      body.turnstileToken,
+      request.headers.get("CF-Connecting-IP")
+    );
+    if (!passed) {
+      return json({ error: "Bot verification failed. Please try again." }, 403);
+    }
+  }
+
   const now = Date.now();
   const roomId = randomRoomId();
   const creatorToken = randomToken();

--- a/workers/api/wrangler.jsonc
+++ b/workers/api/wrangler.jsonc
@@ -1,7 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "elm-chat",
-  "account_id": "485a8b721eeb6afa98c6e4071b50fe04",
   "main": "src/index.ts",
   "compatibility_date": "2026-04-08",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/api/wrangler.jsonc
+++ b/workers/api/wrangler.jsonc
@@ -5,6 +5,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-04-08",
   "compatibility_flags": ["nodejs_compat"],
+  "dev": {
+    "port": 8799
+  },
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1


### PR DESCRIPTION
## Summary

Turns the branch into a publish-ready state: fixes real bugs, adds encrypted file transfer and Turnstile, makes local dev reliable, removes dead code, and ships complete Cloudflare deployment docs plus project governance/launch materials.

All changes are E2E verified in a browser; the app is deployed and healthy at `https://elm-chat.smb.workers.dev`.

## Bug fixes
- **Message expiry**: indefinite-retention messages no longer vanish for peers after 7 minutes (envelope carried the default instead of `null`).
- **Invite reload lockout**: the session that consumed a one-time invite can reconnect (page reload) instead of being permanently locked out; new sessions and revoked invites are still rejected.
- **Durable Object relay after hibernation** (latent production bug): participant liveness is now derived from live WebSocket attachments instead of an in-memory map that gets wiped on DO hibernation. This was silently breaking every targeted relay (file chunks, per-peer transcript sync) with false `peer_missing` errors.
- **Connection status label** no longer reads a stale room value in the socket close handler.

## Features
- **Encrypted file transfer** over the relay: attach button, chunked AES-GCM (64 KiB) offer/request/serve/reassemble flow, progress UI, blob download, expiry-aware cleanup. Verified two-peer, byte-for-byte, up to 400 KB.
- **Invisible Cloudflare Turnstile** on room creation: runs when `VITE_TURNSTILE_SITE_KEY` is set, verified server-side when `TURNSTILE_SECRET` is set; fully inert (open creation) when unconfigured.

## Transport decision
- Confirmed **relay-everything** (no WebRTC/STUN/TURN). Removed the dead WebRTC peer/signaling/STUN/TURN scaffold so the code matches the shipped architecture. Relay keeps peer IPs private from other room members and needs no TURN — the right fit for the threat model.

## Local dev
- Vite proxies `/api` (+ WebSocket) to `wrangler dev`; Worker pinned to port **8799** to avoid colliding with other Cloudflare projects on 8787.
- Root `npm run dev` runs both; `.vscode/` launch + tasks for run-with-debugger and run-in-default-browser.

## Docs & governance
- Rewrote `docs/architecture.md`, `docs/api-spec.md`, `docs/room-lifecycle.md`, `docs/threat-model.md` to match the encrypted-relay reality (previous docs described a P2P design that never shipped).
- **Complete Cloudflare deployment guide** in the README: one-click + manual paths, account selection, workers.dev subdomain, automatic DO migration, custom domain, Turnstile, verification, troubleshooting.
- `wrangler.jsonc` no longer hardcodes `account_id`, so forks/one-click deploy to the operator's own account.
- Added LICENSE (AGPL v3), CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, issue/PR templates, and growth/launch materials.

## Verification
- `npm run typecheck` and `npm run build` pass.
- Browser-verified: landing, room create/connect, encrypted chat, two-peer file transfer (send + receive UI), Turnstile inert path, stable connection on the dedicated dev port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)