### PR TITLE
Mobile-first design + GitHub social proof

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,8 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="referrer" content="no-referrer" />
+    <meta name="theme-color" content="#f5f5f7" />
     <title>elm chat</title>
   </head>
   <body>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -143,6 +143,16 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
 }
 
+const GITHUB_URL = "https://github.com/shawnbure/elm-chat";
+
+function formatCount(value: number): string {
+  if (value < 1000) {
+    return String(value);
+  }
+  const thousands = value / 1000;
+  return `${thousands.toFixed(thousands < 10 ? 1 : 0).replace(/\.0$/, "")}k`;
+}
+
 function creatorTokenKey(roomId: string): string {
   return `elm-chat:creator:${roomId}`;
 }
@@ -532,6 +542,14 @@ function RemovedFromRoomScreen() {
   );
 }
 
+function GithubMark({ size = 16 }: { size?: number }) {
+  return (
+    <svg aria-hidden="true" fill="currentColor" height={size} viewBox="0 0 16 16" width={size}>
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 012-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
 function FileCard({ file, onDownload }: { file: UiFile; onDownload: () => void }) {
   const percent = Math.round((file.progress ?? 0) * 100);
   return (
@@ -593,6 +611,10 @@ export function App() {
 function LandingPage() {
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [ghStats, setGhStats] = useState<{ stars: number | null; forks: number | null }>({
+    stars: null,
+    forks: null
+  });
   const whyUseUrl =
     "https://github.com/shawnbure/elm-chat/blob/main/docs/why-use-elm-chat.md";
   const articleUrl =
@@ -607,6 +629,23 @@ function LandingPage() {
     unit: "minutes",
     indefinite: false
   });
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/stars")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => {
+        if (active && data) {
+          setGhStats({ stars: data.stars ?? null, forks: data.forks ?? null });
+        }
+      })
+      .catch(() => {
+        // Non-fatal: counts simply stay hidden if the lookup fails.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   function updateDurationIndefinite(kind: DurationKind, checked: boolean) {
     if (kind === "message") {
@@ -772,6 +811,36 @@ function LandingPage() {
             </a>
             <a className="hero-link" href={articleUrl} rel="noreferrer" target="_blank">
               Read the article
+            </a>
+          </div>
+          <a className="github-cta" href={GITHUB_URL} rel="noreferrer" target="_blank">
+            <GithubMark size={22} />
+            <span className="github-cta-copy">
+              <strong>Star us on GitHub</strong>
+              <span>Open source. Audit the code, fork it, run your own.</span>
+            </span>
+            <span className="github-cta-stats" aria-label="GitHub stars and forks">
+              {ghStats.stars !== null ? (
+                <span className="github-stat">
+                  <span aria-hidden="true">★</span> {formatCount(ghStats.stars)}
+                </span>
+              ) : null}
+              {ghStats.forks !== null ? (
+                <span className="github-stat">
+                  <span aria-hidden="true">⑂</span> {formatCount(ghStats.forks)}
+                </span>
+              ) : null}
+            </span>
+          </a>
+          <div className="github-links" aria-label="Project source">
+            <a className="github-mini" href={GITHUB_URL} rel="noreferrer" target="_blank">
+              <GithubMark size={13} /> View source
+            </a>
+            <a className="github-mini" href={`${GITHUB_URL}/fork`} rel="noreferrer" target="_blank">
+              Fork me
+            </a>
+            <a className="github-mini" href={`${GITHUB_URL}/blob/main/apps/web/src/App.tsx`} rel="noreferrer" target="_blank">
+              Read my code
             </a>
           </div>
           <div className="hero-metrics">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -217,7 +217,10 @@ select {
   overflow: hidden;
   padding: 28px;
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: stretch;
+  gap: 12px;
 }
 
 .hero-links {
@@ -259,6 +262,92 @@ select {
 .hero-link:active {
   transform: translateY(0);
   box-shadow: none;
+}
+
+.github-cta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--ink);
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.github-cta:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 10px 24px rgba(31, 26, 23, 0.1);
+}
+
+.github-cta > svg {
+  flex: 0 0 auto;
+}
+
+.github-cta-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.github-cta-copy strong {
+  font-size: 0.98rem;
+}
+
+.github-cta-copy span {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.github-cta-stats {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.github-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent), white 86%);
+  color: var(--accent-strong);
+  white-space: nowrap;
+}
+
+.github-links {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.github-mini {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.github-mini:hover {
+  color: var(--ink);
+  text-decoration: underline;
 }
 
 .signal-grid {
@@ -804,6 +893,7 @@ select {
   }
 }
 
+/* Tablets and small laptops: stack the hero, keep the room app-shell intact. */
 @media (max-width: 900px) {
   .hero {
     grid-template-columns: 1fr;
@@ -811,49 +901,181 @@ select {
   }
 
   .hero-copy {
-    padding: 28px 22px;
+    padding: 30px 24px;
+  }
+
+  .hero-panel {
+    padding: 22px;
+    min-height: 220px;
   }
 
   .hero-links {
-    top: 16px;
-    right: 16px;
-    left: 16px;
-  }
-
-  .room-header,
-  .composer {
-    grid-template-columns: 1fr;
-  }
-
-  .room-header,
-  .composer,
-  .room-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .room-shell {
-    height: auto;
-    min-height: calc(100svh - 36px);
-    overflow: visible;
-  }
-
-  .composer {
-    display: flex;
     position: static;
-  }
-
-  .bubble {
-    max-width: 100%;
+    justify-content: flex-start;
   }
 
   .setting-row {
     grid-template-columns: 1fr;
   }
 
-  .room-strip,
-  .room-toolbar {
+  /* Keep form controls at 16px so mobile browsers don't zoom on focus. */
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
+/* Phones: compact spacing, safe-area insets, a bottom-pinned composer. */
+@media (max-width: 560px) {
+  .landing-shell,
+  .room-shell {
+    padding: 10px;
+    padding-left: max(10px, env(safe-area-inset-left));
+    padding-right: max(10px, env(safe-area-inset-right));
+  }
+
+  .hero h1 {
+    font-size: clamp(2.1rem, 11vw, 3rem);
+  }
+
+  .hero-copy {
+    padding: 22px 18px;
+    border-radius: 22px;
+  }
+
+  .lede {
+    font-size: 0.95rem;
+  }
+
+  .setting-controls {
+    flex-wrap: wrap;
+  }
+
+  .setting-input {
+    flex: 1 1 84px;
+    min-width: 0;
+  }
+
+  .setting-select {
+    flex: 1 1 116px;
+  }
+
+  .hero-actions {
     align-items: stretch;
+  }
+
+  .hero-actions .primary-button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .hero-panel {
+    padding: 18px;
+    min-height: 170px;
+    border-radius: 22px;
+  }
+
+  .github-cta-copy span {
+    display: none;
+  }
+
+  /* Room stays a fixed app shell; the composer sits above the home indicator. */
+  .room-shell {
+    gap: 8px;
+    height: 100svh;
+    height: 100dvh;
+    padding-top: max(10px, env(safe-area-inset-top));
+    padding-bottom: max(10px, env(safe-area-inset-bottom));
+  }
+
+  .room-header,
+  .room-strip,
+  .chat-log,
+  .composer textarea {
+    border-radius: 18px;
+  }
+
+  .room-header,
+  .room-strip {
+    padding: 10px 12px;
+  }
+
+  .room-header {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .room-header h1 {
+    font-size: 1.1rem;
+  }
+
+  .room-subtitle {
+    font-size: 0.85rem;
+  }
+
+  .room-toolbar {
+    width: 100%;
     justify-items: stretch;
+  }
+
+  .room-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .room-actions {
+    width: 100%;
+  }
+
+  .room-actions .secondary-button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  .participant-strip {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .participant-strip::-webkit-scrollbar {
+    display: none;
+  }
+
+  .participant-chip {
+    flex: 0 0 auto;
+  }
+
+  .chat-log {
+    padding: 10px;
+  }
+
+  .bubble {
+    max-width: 88%;
+  }
+
+  /* Two-row composer: [attach] [message] on top, full-width Send below. */
+  .composer {
+    grid-template-columns: auto 1fr;
+    gap: 6px;
+  }
+
+  .composer textarea {
+    min-height: 44px;
+    padding: 10px 12px;
+  }
+
+  .composer-attach {
+    height: 44px;
+    width: 44px;
+  }
+
+  .composer .primary-button {
+    grid-column: 1 / -1;
+    width: 100%;
+    text-align: center;
   }
 }

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -190,11 +190,55 @@ async function handleRevokeInvite(request: Request, roomId: string, env: Env): P
   });
 }
 
+const GITHUB_REPO = "shawnbure/elm-chat";
+const GITHUB_STATS_TTL_MS = 60 * 60 * 1000;
+
+// Cached in the isolate so repeated visitors don't each trigger a GitHub call.
+let githubStatsCache: { at: number; stars: number | null; forks: number | null } | null = null;
+
+// Server-side proxy for the repo's star/fork counts. Fetched from GitHub by the
+// Worker, so visitors' browsers never contact GitHub — keeping the landing page
+// free of third-party requests and tracking.
+async function handleGithubStats(): Promise<Response> {
+  const now = Date.now();
+  if (!githubStatsCache || now - githubStatsCache.at > GITHUB_STATS_TTL_MS) {
+    let stars: number | null = null;
+    let forks: number | null = null;
+    try {
+      const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
+        headers: {
+          "user-agent": "elm-chat",
+          accept: "application/vnd.github+json"
+        }
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { stargazers_count?: number; forks_count?: number };
+        stars = typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+        forks = typeof data.forks_count === "number" ? data.forks_count : null;
+      }
+    } catch {
+      // Fall through to nulls; the client hides counts it cannot load.
+    }
+    // Keep a short TTL on failures so a transient error doesn't stick for an hour.
+    githubStatsCache = { at: stars === null ? now - GITHUB_STATS_TTL_MS + 5 * 60 * 1000 : now, stars, forks };
+  }
+
+  return json({
+    repo: GITHUB_REPO,
+    stars: githubStatsCache.stars,
+    forks: githubStatsCache.forks
+  });
+}
+
 function routeApi(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
 
   if (request.method === "POST" && url.pathname === "/api/rooms") {
     return handleCreateRoom(request, env);
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/stars") {
+    return handleGithubStats();
   }
 
   const revokeMatch = url.pathname.match(/^\/api\/rooms\/([^/]+)\/invites\/revoke$/);


### PR DESCRIPTION
## Summary
Makes the app genuinely mobile-friendly and adds in-app GitHub social proof.

### Mobile-first
- `viewport-fit=cover` + `theme-color`; safe-area insets on landing and room.
- **Room** keeps a fixed app-shell on phones: header stacks, participant strip scrolls horizontally, chat log fills the space, and a **two-row composer** ([attach][message] + full-width Send) is pinned above the home indicator.
- **Landing** stacks with full-width actions, wrapped duration controls, and 16px form fields (no iOS zoom-on-focus).
- Verified at 375px (mobile) and 1280px (desktop); chat + file transfer paths unaffected.

### GitHub social proof
- Landing **"Star us on GitHub"** CTA with an inline octocat (no external images), live star/fork counts, and **View source / Fork me / Read my code** links.
- New **`GET /api/stars`** proxies GitHub server-side with an in-isolate cache, so visitors' browsers never contact GitHub — no third-party requests or tracking, and it stays within the app's strict CSP.

### Verification
- `npm run typecheck` + `npm run build` pass.
- Browser-verified mobile and desktop layouts, room create/connect, message send, and the star-count endpoint (server-proxied, 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)