### PR TITLE
Landing layout: info links in main column, GitHub at top of side panel

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -802,9 +802,6 @@ function LandingPage() {
             </p>
           </div>
           {error ? <p className="error-text">{error}</p> : null}
-        </div>
-        <div className="hero-panel">
-          <div className="signal-grid" />
           <div className="hero-links" aria-label="Learn about elm chat">
             <a className="hero-link" href={whyUseUrl} rel="noreferrer" target="_blank">
               Why use this?
@@ -813,6 +810,10 @@ function LandingPage() {
               Read the article
             </a>
           </div>
+        </div>
+        <div className="hero-panel">
+          <div className="signal-grid" />
+          <div className="hero-panel-top">
           <a className="github-cta" href={GITHUB_URL} rel="noreferrer" target="_blank">
             <GithubMark size={22} />
             <span className="github-cta-copy">
@@ -842,6 +843,7 @@ function LandingPage() {
             <a className="github-mini" href={`${GITHUB_URL}/blob/main/apps/web/src/App.tsx`} rel="noreferrer" target="_blank">
               Read my code
             </a>
+          </div>
           </div>
           <div className="hero-metrics">
             <div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -218,21 +218,25 @@ select {
   padding: 28px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: stretch;
   gap: 12px;
 }
 
-.hero-links {
-  position: absolute;
-  top: 22px;
-  right: 22px;
+.hero-panel-top {
+  position: relative;
   z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hero-links {
   display: flex;
   gap: 10px;
   align-items: center;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  margin-top: 18px;
 }
 
 .hero-link {
@@ -333,6 +337,7 @@ select {
   z-index: 1;
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 14px;
 }
 


### PR DESCRIPTION
Move Why use this? / Read the article into the main column; move the GitHub CTA + source links to the top of the side panel (metrics stay at the bottom); center the source links line. Verified desktop + mobile, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)