### PR TITLE
Move info links to top of main column, centered

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -684,6 +684,14 @@ function LandingPage() {
     <main className="landing-shell">
       <section className="hero">
         <div className="hero-copy">
+          <div className="hero-links" aria-label="Learn about elm chat">
+            <a className="hero-link" href={whyUseUrl} rel="noreferrer" target="_blank">
+              Why use this?
+            </a>
+            <a className="hero-link" href={articleUrl} rel="noreferrer" target="_blank">
+              Read the article
+            </a>
+          </div>
           <p className="eyebrow">elm chat</p>
           <h1>Instant chat. Private, secure, fast and disposable.</h1>
           <p className="lede">
@@ -802,14 +810,6 @@ function LandingPage() {
             </p>
           </div>
           {error ? <p className="error-text">{error}</p> : null}
-          <div className="hero-links" aria-label="Learn about elm chat">
-            <a className="hero-link" href={whyUseUrl} rel="noreferrer" target="_blank">
-              Why use this?
-            </a>
-            <a className="hero-link" href={articleUrl} rel="noreferrer" target="_blank">
-              Read the article
-            </a>
-          </div>
         </div>
         <div className="hero-panel">
           <div className="signal-grid" />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -235,8 +235,9 @@ select {
   display: flex;
   gap: 10px;
   align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
-  margin-top: 18px;
+  margin: 0 0 18px;
 }
 
 .hero-link {
@@ -915,8 +916,7 @@ select {
   }
 
   .hero-links {
-    position: static;
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   .setting-row {


### PR DESCRIPTION
Place Why use this? / Read the article at the top of the main column, above the heading, centered (desktop + mobile). Verified, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)