### PR TITLE
Top-align hero copy (remove top whitespace above info links)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -91,7 +91,7 @@ select {
   padding: 42px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .eyebrow {


### PR DESCRIPTION
The main column vertically centered its content, leaving a large empty gap above the top info links. Top-align the content so the links sit at the top. Verified desktop, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)