### PR TITLE
Loop 1 room-gone screen + landing-only cookieless analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,20 @@ To enable it:
 
 With both set, the landing page runs an invisible challenge before creating a room, and the Worker rejects room creation unless the token verifies. With neither set, creation is open.
 
+## Analytics (optional, landing only)
+
+Aggregate, cookieless [Cloudflare Web Analytics](https://developers.cloudflare.com/web-analytics/) can be enabled on the **landing page only**. Room pages (`/c/*`) deliberately keep a strict `script-src 'self'` and never load any third-party beacon — consistent with the [threat model](docs/threat-model.md)'s promise of no third-party analytics on room pages. It stays off until you add a token.
+
+To enable it:
+
+1. In the Cloudflare dashboard, create a **Web Analytics** site and copy its **token**.
+2. Build the web app with the token:
+   `VITE_CF_ANALYTICS_TOKEN=<token> npm run build`
+   (or add it to `apps/web/.env`).
+3. Deploy. The landing page then loads the cookieless beacon; room pages remain untouched.
+
+The Worker automatically relaxes the landing page's CSP to permit the beacon while keeping room pages strict. This measures marketing-surface traffic (landing views); it does not see any room, message, or file activity.
+
 ## Durable Object Lifecycle
 
 Each room is coordinated by a dedicated Durable Object instance.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -594,6 +594,25 @@ function InviteCheckingScreen() {
         <p className="eyebrow">elm chat</p>
         <h1 className="access-title">Checking invite</h1>
         <p className="access-copy">Verifying this one-time invite and joining the room.</p>
+        <MakeYourOwnCallout />
+      </section>
+    </main>
+  );
+}
+
+function RoomGoneScreen({ reason }: { reason?: string }) {
+  return (
+    <main className="room-shell room-shell-centered">
+      <section className="access-screen" aria-live="polite">
+        <p className="eyebrow">elm chat</p>
+        <h1 className="access-title">Room gone</h1>
+        <p className="access-copy">
+          {reason ?? "This conversation self-destructed. Nothing was kept."}
+        </p>
+        <a className="primary-button access-home-link" href="/">
+          Start a new one &rarr;
+        </a>
+        <MakeYourOwnCallout />
       </section>
     </main>
   );
@@ -645,6 +664,22 @@ function LandingPage() {
     return () => {
       active = false;
     };
+  }, []);
+
+  // Cookieless Cloudflare Web Analytics, loaded on the landing surface only.
+  // Room pages never render LandingPage, so they stay free of any third-party
+  // beacon. Inert until VITE_CF_ANALYTICS_TOKEN is configured at build time.
+  useEffect(() => {
+    const token = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
+    if (!token || document.getElementById("cf-analytics-beacon")) {
+      return;
+    }
+    const script = document.createElement("script");
+    script.id = "cf-analytics-beacon";
+    script.defer = true;
+    script.src = "https://static.cloudflareinsights.com/beacon.min.js";
+    script.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+    document.head.appendChild(script);
   }, []);
 
   function updateDurationIndefinite(kind: DurationKind, checked: boolean) {
@@ -884,6 +919,7 @@ function RoomPage({ roomId }: { roomId: string }) {
   const [presence, setPresence] = useState<PresenceSnapshot>({ count: 0, connectedSessionIds: [] });
   const [now, setNow] = useState(Date.now());
   const [roomNotice, setRoomNotice] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState<ActionFeedback>("idle");
   const [destroyFeedback, setDestroyFeedback] = useState<ActionFeedback>("idle");
   const [inviteFeedback, setInviteFeedback] = useState<ActionFeedback>("idle");
@@ -1309,7 +1345,13 @@ function RoomPage({ roomId }: { roomId: string }) {
           }
         });
       } catch (cause) {
-        setError(cause instanceof Error ? cause.message : "Failed to join room.");
+        const message = cause instanceof Error ? cause.message : "Failed to join room.";
+        if (message === "Room not found.") {
+          setNotFound(true);
+          setReady(true);
+          return;
+        }
+        setError(message);
       }
     }
 
@@ -1683,8 +1725,8 @@ function RoomPage({ roomId }: { roomId: string }) {
       setDestroyFeedback("idle");
       const next = await destroyRoom(roomId, creatorToken);
       sendPeerData({ type: "peer_destroy" });
+      setRoomNotice(null);
       setRoom(next);
-      setRoomNotice("Destroying room for everyone...");
     } catch (cause) {
       setDestroying(false);
       setError(cause instanceof Error ? cause.message : "Failed to destroy room.");
@@ -1711,6 +1753,14 @@ function RoomPage({ roomId }: { roomId: string }) {
 
   if (inviteAccess === "invalid") {
     return <InvalidInviteScreen />;
+  }
+
+  if (notFound) {
+    return <RoomGoneScreen reason="This room no longer exists. It may have already self-destructed." />;
+  }
+
+  if (ready && room && room.status !== "open") {
+    return <RoomGoneScreen reason={roomNotice ?? roomStateMessage(room.status)} />;
   }
 
   if (isInviteGuest && (inviteAccess !== "granted" || !room || !ready)) {

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,6 +6,11 @@ interface ImportMetaEnv {
    * Turnstile challenge before creating a room. Leave unset for local dev.
    */
   readonly VITE_TURNSTILE_SITE_KEY?: string;
+  /**
+   * Cloudflare Web Analytics token. When set, the landing page (only — never
+   * room pages) loads the cookieless analytics beacon. Leave unset for local dev.
+   */
+  readonly VITE_CF_ANALYTICS_TOKEN?: string;
 }
 
 interface ImportMeta {

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -27,12 +27,19 @@ function json(payload: unknown, status = 200): Response {
   });
 }
 
-function withSecurityHeaders(response: Response): Response {
+function withSecurityHeaders(response: Response, allowAnalytics = false): Response {
   const headers = new Headers(response.headers);
   headers.set("Referrer-Policy", "no-referrer");
   headers.set("X-Content-Type-Options", "nosniff");
   headers.set("X-Frame-Options", "DENY");
-  headers.set("Content-Security-Policy", "default-src 'self'; connect-src 'self' https: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'");
+  // The Cloudflare Web Analytics beacon is permitted only on the marketing
+  // surface (landing). Room pages keep a strict `script-src 'self'` so they
+  // never load third-party scripts.
+  const scriptSrc = allowAnalytics ? "'self' https://static.cloudflareinsights.com" : "'self'";
+  headers.set(
+    "Content-Security-Policy",
+    `default-src 'self'; connect-src 'self' https: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src ${scriptSrc}; base-uri 'none'; form-action 'self'; frame-ancestors 'none'`
+  );
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -289,6 +296,8 @@ export default {
       }
     }
 
-    return withSecurityHeaders(await env.ASSETS.fetch(request));
+    // Room pages (/c/*) stay strict; the landing may load the analytics beacon.
+    const allowAnalytics = !url.pathname.startsWith("/c/");
+    return withSecurityHeaders(await env.ASSETS.fetch(request), allowAnalytics);
   }
 };

--- a/workers/api/wrangler.jsonc
+++ b/workers/api/wrangler.jsonc
@@ -14,7 +14,8 @@
   "assets": {
     "directory": "../../apps/web/dist",
     "binding": "ASSETS",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
## Loop 1 (highest-leverage growth loop)
- New **"Room gone. Start a new one →"** screen for expired/destroyed/not-found rooms, with the make-your-own callout. Previously these hit a dead closed shell.
- Make-your-own callout also added to the invite-checking screen.

## Analytics (landing only, cookieless, inert)
- Cloudflare Web Analytics beacon loads on the **landing surface only**, gated on `VITE_CF_ANALYTICS_TOKEN`. Room pages never load any third-party beacon — matches the threat model. CSP relaxed only on the landing.

## Bonus security fix
- `run_worker_first`: the landing was previously served as a static asset **bypassing the Worker**, so it had **no security headers** (no CSP/X-Frame-Options). Now the Worker serves every route. Verified assets still serve (200, correct content-type).

## Verified
- typecheck + build pass; room-gone screen confirmed in-browser; per-route CSP confirmed; beacon inert without a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)