### PR TITLE
Strip analytics entirely — strict CSP, no trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,19 +259,9 @@ To enable it:
 
 With both set, the landing page runs an invisible challenge before creating a room, and the Worker rejects room creation unless the token verifies. With neither set, creation is open.
 
-## Analytics (optional, landing only)
+## No Tracking
 
-Aggregate, cookieless [Cloudflare Web Analytics](https://developers.cloudflare.com/web-analytics/) can be enabled on the **landing page only**. Room pages (`/c/*`) deliberately keep a strict `script-src 'self'` and never load any third-party beacon — consistent with the [threat model](docs/threat-model.md)'s promise of no third-party analytics on room pages. It stays off until you add a token.
-
-To enable it:
-
-1. In the Cloudflare dashboard, create a **Web Analytics** site and copy its **token**.
-2. Build the web app with the token:
-   `VITE_CF_ANALYTICS_TOKEN=<token> npm run build`
-   (or add it to `apps/web/.env`).
-3. Deploy. The landing page then loads the cookieless beacon; room pages remain untouched.
-
-The Worker automatically relaxes the landing page's CSP to permit the beacon while keeping room pages strict. This measures marketing-surface traffic (landing views); it does not see any room, message, or file activity.
+elm.chat ships with **no analytics, no beacons, and no third-party scripts** on any page. A strict `Content-Security-Policy` with `script-src 'self'` is applied to every route, so the browser cannot load an external tracker even if one were added by mistake. The only network calls a visitor's browser makes are to elm.chat's own origin. (The GitHub star count on the landing is fetched server-side by the Worker, so visitors' browsers never contact GitHub.)
 
 ## Durable Object Lifecycle
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -666,22 +666,6 @@ function LandingPage() {
     };
   }, []);
 
-  // Cookieless Cloudflare Web Analytics, loaded on the landing surface only.
-  // Room pages never render LandingPage, so they stay free of any third-party
-  // beacon. Inert until VITE_CF_ANALYTICS_TOKEN is configured at build time.
-  useEffect(() => {
-    const token = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
-    if (!token || document.getElementById("cf-analytics-beacon")) {
-      return;
-    }
-    const script = document.createElement("script");
-    script.id = "cf-analytics-beacon";
-    script.defer = true;
-    script.src = "https://static.cloudflareinsights.com/beacon.min.js";
-    script.setAttribute("data-cf-beacon", JSON.stringify({ token }));
-    document.head.appendChild(script);
-  }, []);
-
   function updateDurationIndefinite(kind: DurationKind, checked: boolean) {
     if (kind === "message") {
       setMessageDuration((current) => toggleIndefiniteDuration(current, checked, "7"));

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,11 +6,6 @@ interface ImportMetaEnv {
    * Turnstile challenge before creating a room. Leave unset for local dev.
    */
   readonly VITE_TURNSTILE_SITE_KEY?: string;
-  /**
-   * Cloudflare Web Analytics token. When set, the landing page (only — never
-   * room pages) loads the cookieless analytics beacon. Leave unset for local dev.
-   */
-  readonly VITE_CF_ANALYTICS_TOKEN?: string;
 }
 
 interface ImportMeta {

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -27,18 +27,16 @@ function json(payload: unknown, status = 200): Response {
   });
 }
 
-function withSecurityHeaders(response: Response, allowAnalytics = false): Response {
+function withSecurityHeaders(response: Response): Response {
   const headers = new Headers(response.headers);
   headers.set("Referrer-Policy", "no-referrer");
   headers.set("X-Content-Type-Options", "nosniff");
   headers.set("X-Frame-Options", "DENY");
-  // The Cloudflare Web Analytics beacon is permitted only on the marketing
-  // surface (landing). Room pages keep a strict `script-src 'self'` so they
-  // never load third-party scripts.
-  const scriptSrc = allowAnalytics ? "'self' https://static.cloudflareinsights.com" : "'self'";
+  // Strict, third-party-free policy on every route: no external scripts, no
+  // analytics beacons, no trackers anywhere in the app.
   headers.set(
     "Content-Security-Policy",
-    `default-src 'self'; connect-src 'self' https: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src ${scriptSrc}; base-uri 'none'; form-action 'self'; frame-ancestors 'none'`
+    "default-src 'self'; connect-src 'self' https: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'"
   );
   return new Response(response.body, {
     status: response.status,
@@ -296,8 +294,8 @@ export default {
       }
     }
 
-    // Room pages (/c/*) stay strict; the landing may load the analytics beacon.
-    const allowAnalytics = !url.pathname.startsWith("/c/");
-    return withSecurityHeaders(await env.ASSETS.fetch(request), allowAnalytics);
+    // Every route runs through the Worker (run_worker_first) so security
+    // headers apply consistently, including the landing page.
+    return withSecurityHeaders(await env.ASSETS.fetch(request));
   }
 };


### PR DESCRIPTION
Privacy-first cleanup: remove the (inert) Cloudflare Web Analytics beacon wiring and VITE_CF_ANALYTICS_TOKEN, and revert the CSP to strict `script-src 'self'` on every route so no external script can load anywhere. Kept run_worker_first so the landing keeps its security headers. README now states a No-Tracking policy.

Verified: bundle has 0 analytics refs; landing + room CSP both strict; app renders, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)