### PR TITLE
Add self-maintaining sitemap.xml + robots.txt

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "vite": "^6.3.2"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && node scripts/gen-sitemap.mjs",
     "dev": "vite",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   }

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+# Private, secret, ephemeral room pages must never be crawled or indexed.
+Disallow: /c/
+# API endpoints are not content.
+Disallow: /api/
+
+Sitemap: https://elm.chat/sitemap.xml

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -1,0 +1,37 @@
+// Generates dist/sitemap.xml at build time so `lastmod` is always current —
+// this is what keeps the sitemap "maintained" without manual edits.
+//
+// Only public, indexable URLs belong here. Room pages (/c/:id) are private,
+// secret, and ephemeral, so they are deliberately excluded (and blocked in
+// robots.txt). If real marketing/SEO routes are added later, list them below.
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+
+const ORIGIN = process.env.SITE_ORIGIN ?? "https://elm.chat";
+
+const urls = [{ path: "/", changefreq: "weekly", priority: "1.0" }];
+
+const lastmod = new Date().toISOString().slice(0, 10);
+
+const body = urls
+  .map(
+    ({ path, changefreq, priority }) =>
+      `  <url>\n` +
+      `    <loc>${ORIGIN}${path}</loc>\n` +
+      `    <lastmod>${lastmod}</lastmod>\n` +
+      `    <changefreq>${changefreq}</changefreq>\n` +
+      `    <priority>${priority}</priority>\n` +
+      `  </url>`
+  )
+  .join("\n");
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${body}
+</urlset>
+`;
+
+if (!existsSync("dist")) {
+  mkdirSync("dist", { recursive: true });
+}
+writeFileSync("dist/sitemap.xml", xml);
+console.log(`sitemap.xml generated for ${ORIGIN} (lastmod ${lastmod}, ${urls.length} url)`);


### PR DESCRIPTION
Adds /sitemap.xml (homepage only; regenerated with a fresh lastmod on every build) and /robots.txt (blocks /c/ room pages + /api/, references the sitemap). Room pages stay out of search indexes. Verified: both serve 200 with correct content-types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)