### PR TITLE
Measure privacy-safe growth events

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -506,10 +506,24 @@ function roomStateMessage(status: RoomMetadata["status"], reason?: string): stri
 // recipient reaches. No tracking, no telemetry — just a way for a first-time
 // visitor to learn they can spin up their own room. elm.chat's main organic loop.
 function MakeYourOwnCallout() {
+  function recordClick() {
+    const body = JSON.stringify({ event: "make_your_own_clicked" });
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon("/api/growth", new Blob([body], { type: "application/json" }));
+      return;
+    }
+    void fetch("/api/growth", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      keepalive: true
+    });
+  }
+
   return (
     <p className="make-your-own">
       This secure room was made with elm.chat.{" "}
-      <a className="make-your-own-link" href="/">
+      <a className="make-your-own-link" href="/?source=invite" onClick={recordClick}>
         Create your own &mdash; free, no signup.
       </a>
     </p>
@@ -691,6 +705,10 @@ function LandingPage() {
       const secret = generateRoomSecret();
       const turnstileToken = await getTurnstileToken();
       const room = await createRoom({
+        acquisitionSource:
+          new URLSearchParams(window.location.search).get("source") === "invite"
+            ? "invite"
+            : undefined,
         disappearAfterReadSeconds: parseDurationDraft(
           messageDuration,
           7,

--- a/durable-objects/room/src/room.ts
+++ b/durable-objects/room/src/room.ts
@@ -49,6 +49,7 @@ type RoomBootstrap = Pick<
 >;
 
 export interface Env {
+  GROWTH?: AnalyticsEngineDataset;
   ROOM_OBJECT: DurableObjectNamespace<RoomDurableObject>;
 }
 
@@ -306,6 +307,11 @@ export class RoomDurableObject extends DurableObject<Env> {
         invite.consumedBySessionId = payload.sessionId;
         this.invites.set(invite.token, invite);
         await this.persistInvites();
+        this.env.GROWTH?.writeDataPoint({
+          indexes: ["invite_redeemed"],
+          blobs: [""],
+          doubles: [1]
+        });
       }
     }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,6 +20,7 @@ export interface CreateRoomRequest {
   disappearAfterReadSeconds?: number | null;
   inactivityTimeoutMs?: number | null;
   maxAgeMs?: number | null;
+  acquisitionSource?: "invite";
   turnstileToken?: string;
 }
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -11,9 +11,20 @@ export { RoomDurableObject };
 
 type Env = {
   ASSETS: Fetcher;
+  GROWTH?: AnalyticsEngineDataset;
   ROOM_OBJECT: DurableObjectNamespace<RoomDurableObject>;
   TURNSTILE_SECRET?: string;
 };
+
+type GrowthEvent = "make_your_own_clicked" | "room_created" | "invite_created";
+
+function recordGrowth(env: Env, event: GrowthEvent, source = ""): void {
+  env.GROWTH?.writeDataPoint({
+    indexes: [event],
+    blobs: [source],
+    doubles: [1]
+  });
+}
 
 function json(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -32,8 +43,8 @@ function withSecurityHeaders(response: Response): Response {
   headers.set("Referrer-Policy", "no-referrer");
   headers.set("X-Content-Type-Options", "nosniff");
   headers.set("X-Frame-Options", "DENY");
-  // Strict, third-party-free policy on every route: no external scripts, no
-  // analytics beacons, no trackers anywhere in the app.
+  // Strict, third-party-free policy on every route. Growth counters are written
+  // server-side to Cloudflare Analytics Engine and never load tracking scripts.
   headers.set(
     "Content-Security-Policy",
     "default-src 'self'; connect-src 'self' https: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'"
@@ -149,6 +160,7 @@ async function handleCreateRoom(request: Request, env: Env): Promise<Response> {
     body: JSON.stringify(response)
   });
 
+  recordGrowth(env, "room_created", body.acquisitionSource === "invite" ? "invite" : "direct");
   return json(response, 201);
 }
 
@@ -174,10 +186,14 @@ async function handleRoomWebSocket(request: Request, roomId: string, env: Env): 
 async function handleCreateInvite(request: Request, roomId: string, env: Env): Promise<Response> {
   const payload = await safeJson<{ creatorToken: string; ttlMs?: number }>(request);
   const stub = env.ROOM_OBJECT.getByName(roomId);
-  return stub.fetch("https://room/internal/invites/create", {
+  const response = await stub.fetch("https://room/internal/invites/create", {
     method: "POST",
     body: JSON.stringify(payload)
   });
+  if (response.ok) {
+    recordGrowth(env, "invite_created");
+  }
+  return response;
 }
 
 async function handleListInvites(request: Request, roomId: string, env: Env): Promise<Response> {
@@ -237,6 +253,18 @@ async function handleGithubStats(): Promise<Response> {
 
 function routeApi(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
+
+  if (request.method === "POST" && url.pathname === "/api/growth") {
+    return safeJson<{ event?: string }>(request)
+      .then(({ event }) => {
+        if (event !== "make_your_own_clicked") {
+          return json({ error: "Unsupported event." }, 400);
+        }
+        recordGrowth(env, event);
+        return new Response(null, { status: 204 });
+      })
+      .catch(() => json({ error: "Invalid event." }, 400));
+  }
 
   if (request.method === "POST" && url.pathname === "/api/rooms") {
     return handleCreateRoom(request, env);

--- a/workers/api/worker-configuration.d.ts
+++ b/workers/api/worker-configuration.d.ts
@@ -4,6 +4,14 @@ interface Fetcher {
   fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
 }
 
+interface AnalyticsEngineDataset {
+  writeDataPoint(event: {
+    indexes?: string[];
+    blobs?: string[];
+    doubles?: number[];
+  }): void;
+}
+
 interface DurableObjectState {
   storage: {
     get<T>(key: string): Promise<T | undefined>;
@@ -42,4 +50,3 @@ declare module "cloudflare:workers" {
     constructor(ctx: DurableObjectState, env: Env);
   }
 }
-

--- a/workers/api/wrangler.jsonc
+++ b/workers/api/wrangler.jsonc
@@ -17,6 +17,12 @@
     "not_found_handling": "single-page-application",
     "run_worker_first": true
   },
+  "analytics_engine_datasets": [
+    {
+      "binding": "GROWTH",
+      "dataset": "elm_chat_growth"
+    }
+  ],
   "durable_objects": {
     "bindings": [
       {


### PR DESCRIPTION
## What changed

- records aggregate-only Analytics Engine events for rooms created, invites created, invites redeemed, and “make your own” clicks
- attributes a room created from the invite callout without storing a user or room identifier
- keeps the client free of third-party analytics scripts and cookies

## Privacy model

Each event stores only an event name, an optional `direct`/`invite` acquisition source, and a count of one. It does not store room IDs, invite tokens, IP addresses, message data, or participant identifiers.

## Verification

- `npm run typecheck`
- `npm run build`
- Wrangler dry-run resolves the `elm_chat_growth` Analytics Engine binding

The repository does not currently define a root `npm test` script.
