### PR TITLE
Expand the one-time secret search cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
 
-Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), or follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely).
+Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), or compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat).
 
 ## Run your own in one click
 

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -11,7 +11,8 @@ const ORIGIN = process.env.SITE_ORIGIN ?? "https://elm.chat";
 const urls = [
   { path: "/", changefreq: "weekly", priority: "1.0" },
   { path: "/self-destructing-chat", changefreq: "monthly", priority: "0.8" },
-  { path: "/send-a-password-securely", changefreq: "monthly", priority: "0.8" }
+  { path: "/send-a-password-securely", changefreq: "monthly", priority: "0.8" },
+  { path: "/one-time-secret-chat", changefreq: "monthly", priority: "0.8" }
 ];
 
 const lastmod = new Date().toISOString().slice(0, 10);

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -51,10 +51,34 @@ const pages = {
         <p>There is no account or contact list. The room secret stays in the URL fragment during normal use, message and file content is encrypted in the browser, and the relay does not persist a server-side transcript. Invites are single-use and revocable.</p>
         <p>This reduces durable copies; it cannot protect a credential from a compromised device, clipboard manager, screenshot, malicious recipient, or failure to rotate it afterward.</p>
       </section>`
+  },
+  "one-time-secret-chat": {
+    title: "One-time secret or disposable chat? Choose the right handoff",
+    description:
+      "Compare a one-time secret link with a disposable encrypted chat room for passwords, API keys, files, and sensitive live coordination.",
+    eyebrow: "One-time secret alternative",
+    intro:
+      "A one-time secret link is excellent when one person needs to reveal one value once. Some handoffs become a conversation, and that changes what the tool needs to do.",
+    body: `
+      <section>
+        <h2>Use a one-time secret for a one-way reveal</h2>
+        <p>If the entire task is “open this value once,” a purpose-built one-time secret service is the simpler choice. It minimizes interaction and gives the recipient one clear action.</p>
+        <p>Rotate the credential afterward when practical. A disappearing link cannot undo a screenshot, clipboard capture, compromised browser, or malicious recipient.</p>
+      </section>
+      <section>
+        <h2>Use a disposable room when the handoff talks back</h2>
+        <p>A live room fits when the recipient needs to confirm access, request a second value, clarify which environment to use, or exchange an encrypted file. The creator can issue a single-use invite and destroy the room when the exchange is finished.</p>
+        <p>elm.chat encrypts message and file content in the browser and does not persist a server-side transcript. Its relay still observes connection metadata such as timing, sizes, IP addresses, and presence.</p>
+      </section>`
   }
 };
 
 const shell = readFileSync("dist/index.html", "utf8");
+const guideLabels = {
+  "self-destructing-chat": "What self-destructing chat should mean",
+  "send-a-password-securely": "How to send a password securely",
+  "one-time-secret-chat": "One-time secret vs disposable chat"
+};
 
 for (const [slug, page] of Object.entries(pages)) {
   const canonical = `${ORIGIN}/${slug}`;
@@ -81,6 +105,15 @@ for (const [slug, page] of Object.entries(pages)) {
             <p>elm.chat has not had an independent security audit. Review the <a href="https://github.com/shawnbure/elm-chat/blob/main/docs/threat-model.md">public threat model</a> before using it for a sensitive situation.</p>
           </aside>
         </div>
+        <aside class="marketing-related" aria-label="More guides">
+          <p class="eyebrow">More guides</p>
+          <ul>
+            ${Object.entries(guideLabels)
+              .filter(([guideSlug]) => guideSlug !== slug)
+              .map(([guideSlug, label]) => `<li><a href="/${guideSlug}">${label}</a></li>`)
+              .join("")}
+          </ul>
+        </aside>
         <footer class="marketing-footer-cta">
           <p class="eyebrow">One conversation. Then gone.</p>
           <h2>Create a room without an account</h2>

--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -4,7 +4,8 @@ const keyLocation = `https://${host}/${key}.txt`;
 const urlList = [
   `https://${host}/`,
   `https://${host}/self-destructing-chat`,
-  `https://${host}/send-a-password-securely`
+  `https://${host}/send-a-password-securely`,
+  `https://${host}/one-time-secret-chat`
 ];
 
 const response = await fetch("https://api.indexnow.org/indexnow", {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -86,7 +86,8 @@ function roomPathname(): { view: View; roomId?: string; marketingSlug?: Marketin
   const marketingSlug = window.location.pathname.replace(/^\/|\/$/g, "") as MarketingSlug;
   if (
     marketingSlug === "self-destructing-chat" ||
-    marketingSlug === "send-a-password-securely"
+    marketingSlug === "send-a-password-securely" ||
+    marketingSlug === "one-time-secret-chat"
   ) {
     return { view: "marketing", marketingSlug };
   }

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -3,7 +3,10 @@ import { useEffect, type ReactNode } from "react";
 const GITHUB_URL = "https://github.com/shawnbure/elm-chat";
 const THREAT_MODEL_URL = `${GITHUB_URL}/blob/main/docs/threat-model.md`;
 
-export type MarketingSlug = "self-destructing-chat" | "send-a-password-securely";
+export type MarketingSlug =
+  | "self-destructing-chat"
+  | "send-a-password-securely"
+  | "one-time-secret-chat";
 
 type MarketingPageContent = {
   description: string;
@@ -106,6 +109,46 @@ const pages: Record<MarketingSlug, MarketingPageContent> = {
         <Limitations />
       </>
     )
+  },
+  "one-time-secret-chat": {
+    title: "One-time secret or disposable chat? Choose the right handoff",
+    description:
+      "Compare a one-time secret link with a disposable encrypted chat room for passwords, API keys, files, and sensitive live coordination.",
+    eyebrow: "One-time secret alternative",
+    intro:
+      "A one-time secret link is excellent when one person needs to reveal one value once. Some handoffs become a conversation, and that changes what the tool needs to do.",
+    body: (
+      <>
+        <section>
+          <h2>Use a one-time secret for a one-way reveal</h2>
+          <p>
+            If the entire task is “open this value once,” a purpose-built one-time secret service
+            is the simpler choice. It minimizes interaction and gives the recipient one clear
+            action.
+          </p>
+          <p>
+            Rotate the credential afterward when practical. A disappearing link cannot undo a
+            screenshot, clipboard capture, compromised browser, or malicious recipient.
+          </p>
+        </section>
+
+        <section>
+          <h2>Use a disposable room when the handoff talks back</h2>
+          <p>
+            A live room fits when the recipient needs to confirm access, request a second value,
+            clarify which environment to use, or exchange an encrypted file. The creator can issue
+            a single-use invite and destroy the room when the exchange is finished.
+          </p>
+          <p>
+            elm.chat encrypts message and file content in the browser and does not persist a
+            server-side transcript. Its relay still observes connection metadata such as timing,
+            sizes, IP addresses, and presence.
+          </p>
+        </section>
+
+        <Limitations />
+      </>
+    )
   }
 };
 
@@ -172,6 +215,7 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
         </header>
 
         <div className="marketing-body">{page.body}</div>
+        <RelatedGuides current={slug} />
 
         <footer className="marketing-footer-cta">
           <p className="eyebrow">One conversation. Then gone.</p>
@@ -186,5 +230,28 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
         </footer>
       </article>
     </main>
+  );
+}
+
+function RelatedGuides({ current }: { current: MarketingSlug }) {
+  const guides: Array<{ slug: MarketingSlug; label: string }> = [
+    { slug: "self-destructing-chat", label: "What self-destructing chat should mean" },
+    { slug: "send-a-password-securely", label: "How to send a password securely" },
+    { slug: "one-time-secret-chat", label: "One-time secret vs disposable chat" }
+  ];
+
+  return (
+    <aside className="marketing-related" aria-label="More guides">
+      <p className="eyebrow">More guides</p>
+      <ul>
+        {guides
+          .filter((guide) => guide.slug !== current)
+          .map((guide) => (
+            <li key={guide.slug}>
+              <a href={`/${guide.slug}`}>{guide.label}</a>
+            </li>
+          ))}
+      </ul>
+    </aside>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -943,6 +943,28 @@ select {
   padding: clamp(28px, 6vw, 64px);
 }
 
+.marketing-related {
+  margin: 2.5rem 0;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+}
+
+.marketing-related ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  margin: 0.7rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.marketing-related a {
+  color: var(--ink);
+  font-weight: 650;
+  text-underline-offset: 0.18em;
+}
+
 .marketing-article > header {
   background:
     radial-gradient(circle at top right, rgba(0, 122, 255, 0.1), transparent 42%),


### PR DESCRIPTION
## What changed

- adds a third high-intent guide comparing one-time secret links with disposable live chat
- adds related-guide links across the acquisition pages to form a crawlable topic cluster
- includes the new guide in the sitemap, IndexNow submission, and GitHub README
- prerenders the guide with canonical and social metadata

## Positioning

The page recommends a purpose-built one-time secret for simple one-way reveals and elm.chat only when the handoff needs live clarification, another value, or an encrypted file. It includes the existing no-audit and relay-metadata disclosures.

## Verification

- `npm run typecheck`
- `npm run build`
- prerendered output contains the title, canonical URL, article content, and related links
