### PR TITLE
Publish the Durable Objects architecture story

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
 
-Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), or compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat).
+Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), or explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare).
 
 ## Run your own in one click
 

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -12,7 +12,8 @@ const urls = [
   { path: "/", changefreq: "weekly", priority: "1.0" },
   { path: "/self-destructing-chat", changefreq: "monthly", priority: "0.8" },
   { path: "/send-a-password-securely", changefreq: "monthly", priority: "0.8" },
-  { path: "/one-time-secret-chat", changefreq: "monthly", priority: "0.8" }
+  { path: "/one-time-secret-chat", changefreq: "monthly", priority: "0.8" },
+  { path: "/building-ephemeral-chat-cloudflare", changefreq: "monthly", priority: "0.8" }
 ];
 
 const lastmod = new Date().toISOString().slice(0, 10);

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -70,6 +70,54 @@ const pages = {
         <p>A live room fits when the recipient needs to confirm access, request a second value, clarify which environment to use, or exchange an encrypted file. The creator can issue a single-use invite and destroy the room when the exchange is finished.</p>
         <p>elm.chat encrypts message and file content in the browser and does not persist a server-side transcript. Its relay still observes connection metadata such as timing, sizes, IP addresses, and presence.</p>
       </section>`
+  },
+  "building-ephemeral-chat-cloudflare": {
+    title: "Building ephemeral encrypted chat with Cloudflare Durable Objects",
+    description:
+      "A technical walkthrough of elm.chat's React, Web Crypto, Cloudflare Worker, Durable Object, WebSocket, encryption, and disposable-room architecture.",
+    eyebrow: "Architecture walkthrough",
+    intro:
+      "elm.chat uses one Cloudflare Worker and one Durable Object per room to coordinate a live encrypted conversation without turning the server into a transcript database.",
+    body: `
+      <section>
+        <h2>The shape of the system</h2>
+        <p>The React client creates rooms, derives keys with Web Crypto, encrypts messages and files, and maintains the current transcript in memory. A single Cloudflare Worker serves that app and routes the room API. One Durable Object per room owns membership, presence, one-time invites, expiry, and a live WebSocket relay.</p>
+        <p>The Durable Object persists room metadata and invite state. It relays encrypted message envelopes, encrypted file chunks, and peer-supplied transcript sync payloads without persisting those payloads as a server-side transcript.</p>
+      </section>
+      <section>
+        <h2>From room creation to encrypted relay</h2>
+        <ol>
+          <li>The browser generates a random 256-bit room secret.</li>
+          <li>The Worker creates room metadata and addresses a Durable Object by room ID.</li>
+          <li>The secret stays in the URL fragment during normal navigation.</li>
+          <li>The browser derives an AES-GCM-256 room key with HKDF-SHA-256.</li>
+          <li>Participants join through creator-issued, single-use invite links.</li>
+          <li>A single WebSocket carries encrypted chat, file, presence, and sync events.</li>
+          <li>The room expires after its policy or is destroyed by the creator.</li>
+        </ol>
+        <p>Newly connected participants request transcript sync from clients that are already in the room. If no connected client still has an item, the server cannot reconstruct it. That loss is part of the disposable model rather than a durability bug.</p>
+      </section>
+      <section>
+        <h2>Why an encrypted relay instead of WebRTC</h2>
+        <p>Direct WebRTC is attractive, but ICE negotiation can reveal participant IP addresses to other room members, and reliable connectivity often requires a TURN relay anyway. elm.chat deliberately sends ciphertext through the Durable Object so participants never connect directly and the flow works on restrictive networks.</p>
+        <p>This is a tradeoff, not magic. Cloudflare can still observe IP addresses, connection timing, payload sizes, and presence. The relay cannot read message or file plaintext, but elm.chat does not claim to hide metadata from its infrastructure.</p>
+      </section>
+      <section>
+        <h2>What is encrypted—and what is not</h2>
+        <ul>
+          <li>Messages use AES-GCM with a fresh random nonce per message.</li>
+          <li>Files are split into 64 KiB chunks and encrypted chunk by chunk.</li>
+          <li>The browser holds the room key and current transcript in memory.</li>
+          <li>The server stores room policy, status, creator capability, and invite state.</li>
+          <li>Ephemeral identity keys exist, but message authentication is not implemented yet.</li>
+        </ul>
+        <p>The current design does not solve device compromise, screenshots, malicious recipients, traffic analysis, denial of service, or strong anonymous routing. It has not had an independent security audit.</p>
+      </section>
+      <section>
+        <h2>Fork it, inspect it, or run your own</h2>
+        <p>The complete TypeScript project is AGPL-3.0 licensed. The repository includes the architecture, threat model, deployment instructions, contributor guide, and a one-click Cloudflare deploy path.</p>
+        <p><a href="https://github.com/shawnbure/elm-chat">Read the source and deployment guide</a>.</p>
+      </section>`
   }
 };
 
@@ -77,7 +125,8 @@ const shell = readFileSync("dist/index.html", "utf8");
 const guideLabels = {
   "self-destructing-chat": "What self-destructing chat should mean",
   "send-a-password-securely": "How to send a password securely",
-  "one-time-secret-chat": "One-time secret vs disposable chat"
+  "one-time-secret-chat": "One-time secret vs disposable chat",
+  "building-ephemeral-chat-cloudflare": "How elm.chat works on Cloudflare"
 };
 
 for (const [slug, page] of Object.entries(pages)) {

--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -5,7 +5,8 @@ const urlList = [
   `https://${host}/`,
   `https://${host}/self-destructing-chat`,
   `https://${host}/send-a-password-securely`,
-  `https://${host}/one-time-secret-chat`
+  `https://${host}/one-time-secret-chat`,
+  `https://${host}/building-ephemeral-chat-cloudflare`
 ];
 
 const response = await fetch("https://api.indexnow.org/indexnow", {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -87,7 +87,8 @@ function roomPathname(): { view: View; roomId?: string; marketingSlug?: Marketin
   if (
     marketingSlug === "self-destructing-chat" ||
     marketingSlug === "send-a-password-securely" ||
-    marketingSlug === "one-time-secret-chat"
+    marketingSlug === "one-time-secret-chat" ||
+    marketingSlug === "building-ephemeral-chat-cloudflare"
   ) {
     return { view: "marketing", marketingSlug };
   }

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -6,7 +6,8 @@ const THREAT_MODEL_URL = `${GITHUB_URL}/blob/main/docs/threat-model.md`;
 export type MarketingSlug =
   | "self-destructing-chat"
   | "send-a-password-securely"
-  | "one-time-secret-chat";
+  | "one-time-secret-chat"
+  | "building-ephemeral-chat-cloudflare";
 
 type MarketingPageContent = {
   description: string;
@@ -149,6 +150,98 @@ const pages: Record<MarketingSlug, MarketingPageContent> = {
         <Limitations />
       </>
     )
+  },
+  "building-ephemeral-chat-cloudflare": {
+    title: "Building ephemeral encrypted chat with Cloudflare Durable Objects",
+    description:
+      "A technical walkthrough of elm.chat's React, Web Crypto, Cloudflare Worker, Durable Object, WebSocket, encryption, and disposable-room architecture.",
+    eyebrow: "Architecture walkthrough",
+    intro:
+      "elm.chat uses one Cloudflare Worker and one Durable Object per room to coordinate a live encrypted conversation without turning the server into a transcript database.",
+    body: (
+      <>
+        <section>
+          <h2>The shape of the system</h2>
+          <p>
+            The React client creates rooms, derives keys with Web Crypto, encrypts messages and
+            files, and maintains the current transcript in memory. A single Cloudflare Worker serves
+            that app and routes the room API. One Durable Object per room owns membership, presence,
+            one-time invites, expiry, and a live WebSocket relay.
+          </p>
+          <p>
+            The Durable Object persists room metadata and invite state. It relays encrypted message
+            envelopes, encrypted file chunks, and peer-supplied transcript sync payloads without
+            persisting those payloads as a server-side transcript.
+          </p>
+        </section>
+
+        <section>
+          <h2>From room creation to encrypted relay</h2>
+          <ol>
+            <li>The browser generates a random 256-bit room secret.</li>
+            <li>The Worker creates room metadata and addresses a Durable Object by room ID.</li>
+            <li>The secret stays in the URL fragment during normal navigation.</li>
+            <li>The browser derives an AES-GCM-256 room key with HKDF-SHA-256.</li>
+            <li>Participants join through creator-issued, single-use invite links.</li>
+            <li>A single WebSocket carries encrypted chat, file, presence, and sync events.</li>
+            <li>The room expires after its policy or is destroyed by the creator.</li>
+          </ol>
+          <p>
+            Newly connected participants request transcript sync from clients that are already in
+            the room. If no connected client still has an item, the server cannot reconstruct it.
+            That loss is part of the disposable model rather than a durability bug.
+          </p>
+        </section>
+
+        <section>
+          <h2>Why an encrypted relay instead of WebRTC</h2>
+          <p>
+            Direct WebRTC is attractive, but ICE negotiation can reveal participant IP addresses to
+            other room members, and reliable connectivity often requires a TURN relay anyway.
+            elm.chat deliberately sends ciphertext through the Durable Object so participants never
+            connect directly and the flow works on restrictive networks.
+          </p>
+          <p>
+            This is a tradeoff, not magic. Cloudflare can still observe IP addresses, connection
+            timing, payload sizes, and presence. The relay cannot read message or file plaintext,
+            but elm.chat does not claim to hide metadata from its infrastructure.
+          </p>
+        </section>
+
+        <section>
+          <h2>What is encrypted—and what is not</h2>
+          <ul>
+            <li>Messages use AES-GCM with a fresh random nonce per message.</li>
+            <li>Files are split into 64 KiB chunks and encrypted chunk by chunk.</li>
+            <li>The browser holds the room key and current transcript in memory.</li>
+            <li>The server stores room policy, status, creator capability, and invite state.</li>
+            <li>Ephemeral identity keys exist, but message authentication is not implemented yet.</li>
+          </ul>
+          <p>
+            The current design does not solve device compromise, screenshots, malicious recipients,
+            traffic analysis, denial of service, or strong anonymous routing. It has not had an
+            independent security audit.
+          </p>
+        </section>
+
+        <section>
+          <h2>Fork it, inspect it, or run your own</h2>
+          <p>
+            The complete TypeScript project is AGPL-3.0 licensed. The repository includes the
+            architecture, threat model, deployment instructions, contributor guide, and a
+            one-click Cloudflare deploy path.
+          </p>
+          <p>
+            <a href={GITHUB_URL} rel="noreferrer" target="_blank">
+              Read the source and deployment guide
+            </a>
+            .
+          </p>
+        </section>
+
+        <Limitations />
+      </>
+    )
   }
 };
 
@@ -237,7 +330,11 @@ function RelatedGuides({ current }: { current: MarketingSlug }) {
   const guides: Array<{ slug: MarketingSlug; label: string }> = [
     { slug: "self-destructing-chat", label: "What self-destructing chat should mean" },
     { slug: "send-a-password-securely", label: "How to send a password securely" },
-    { slug: "one-time-secret-chat", label: "One-time secret vs disposable chat" }
+    { slug: "one-time-secret-chat", label: "One-time secret vs disposable chat" },
+    {
+      slug: "building-ephemeral-chat-cloudflare",
+      label: "How elm.chat works on Cloudflare"
+    }
   ];
 
   return (

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -216,7 +216,8 @@ const GITHUB_STATS_TTL_MS = 60 * 60 * 1000;
 const MARKETING_PATHS = new Set([
   "/self-destructing-chat",
   "/send-a-password-securely",
-  "/one-time-secret-chat"
+  "/one-time-secret-chat",
+  "/building-ephemeral-chat-cloudflare"
 ]);
 
 // Cached in the isolate so repeated visitors don't each trigger a GitHub call.


### PR DESCRIPTION
Adds a crawler-ready technical acquisition page explaining elm.chat's React, Web Crypto, Worker, Durable Object, and WebSocket relay design. It covers the room lifecycle, HKDF/AES-GCM flow, client-supplied transcript sync, why relay was chosen over WebRTC, persisted vs relayed data, self-hosting, metadata visibility, missing message authentication, and the no-audit caveat. The page is linked from the README and guide cluster, included in the sitemap/IndexNow submission, and routed to prerendered HTML. Verified with typecheck, production build, unique canonical/Open Graph tags, and article-content checks.