### PR TITLE
Add the official Built with Cloudflare badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
+[![Built with Cloudflare](https://workers.cloudflare.com/built-with-cloudflare.svg)](https://elm.chat/building-ephemeral-chat-cloudflare)
 ![Stars](https://img.shields.io/github/stars/shawnbure/elm-chat?style=social)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 


### PR DESCRIPTION
Adds Cloudflare's official Built with Cloudflare badge to the README and links it to elm.chat's detailed Durable Objects architecture walkthrough. The badge asset follows Cloudflare's current documented embed snippet; the destination keeps visitors on the project's honest technical explanation and threat-model tradeoffs.