### PR TITLE
Measure which acquisition pages create rooms

### DIFF
--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -145,7 +145,7 @@ for (const [slug, page] of Object.entries(pages)) {
           <p class="eyebrow">${page.eyebrow}</p>
           <h1>${page.title}</h1>
           <p class="marketing-intro">${page.intro}</p>
-          <a class="primary-button marketing-primary-cta" href="/">Create a disposable room</a>
+          <a class="primary-button marketing-primary-cta" href="/?source=${slug}">Create a disposable room</a>
         </header>
         <div class="marketing-body">
           ${page.body}
@@ -167,7 +167,7 @@ for (const [slug, page] of Object.entries(pages)) {
           <p class="eyebrow">One conversation. Then gone.</p>
           <h2>Create a room without an account</h2>
           <p>Set the message and room lifetime, issue a single-use invite, and destroy the room when you are finished.</p>
-          <a class="primary-button marketing-primary-cta" href="/">Open elm.chat</a>
+          <a class="primary-button marketing-primary-cta" href="/?source=${slug}">Open elm.chat</a>
         </footer>
       </article>
     </main>`;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import {
 } from "@elm-chat/crypto";
 import {
   FILE_CHUNK_BYTES,
+  isAcquisitionSource,
   MAX_FILE_BYTES,
   MAX_TRANSCRIPT_SYNC_MESSAGES,
   type CreateRoomRequest,
@@ -25,6 +26,7 @@ import {
   type ServerEvent,
 } from "@elm-chat/shared";
 import { startTransition, useEffect, useRef, useState, type CSSProperties } from "react";
+import { recordGrowthEvent } from "./growth";
 import { MarketingPage, type MarketingSlug } from "./MarketingPage";
 
 type View = "landing" | "marketing" | "room";
@@ -505,17 +507,7 @@ function roomStateMessage(status: RoomMetadata["status"], reason?: string): stri
 }
 
 function recordMakeYourOwnClick() {
-  const body = JSON.stringify({ event: "make_your_own_clicked" });
-  if (navigator.sendBeacon) {
-    navigator.sendBeacon("/api/growth", new Blob([body], { type: "application/json" }));
-    return;
-  }
-  void fetch("/api/growth", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body,
-    keepalive: true
-  });
+  recordGrowthEvent("make_your_own_clicked");
 }
 
 // Privacy-safe growth callout for an invite recipient. The aggregate event
@@ -721,11 +713,9 @@ function LandingPage() {
       setError(null);
       const secret = generateRoomSecret();
       const turnstileToken = await getTurnstileToken();
+      const source = new URLSearchParams(window.location.search).get("source");
       const room = await createRoom({
-        acquisitionSource:
-          new URLSearchParams(window.location.search).get("source") === "invite"
-            ? "invite"
-            : undefined,
+        acquisitionSource: isAcquisitionSource(source) ? source : undefined,
         disappearAfterReadSeconds: parseDurationDraft(
           messageDuration,
           7,

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -1,13 +1,11 @@
+import type { MarketingAcquisitionSource } from "@elm-chat/shared";
 import { useEffect, type ReactNode } from "react";
+import { recordGrowthEvent } from "./growth";
 
 const GITHUB_URL = "https://github.com/shawnbure/elm-chat";
 const THREAT_MODEL_URL = `${GITHUB_URL}/blob/main/docs/threat-model.md`;
 
-export type MarketingSlug =
-  | "self-destructing-chat"
-  | "send-a-password-securely"
-  | "one-time-secret-chat"
-  | "building-ephemeral-chat-cloudflare";
+export type MarketingSlug = MarketingAcquisitionSource;
 
 type MarketingPageContent = {
   description: string;
@@ -262,6 +260,7 @@ function Limitations() {
 
 export function MarketingPage({ slug }: { slug: MarketingSlug }) {
   const page = pages[slug];
+  const roomHref = `/?source=${slug}`;
 
   useEffect(() => {
     const previousTitle = document.title;
@@ -302,7 +301,11 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
           <p className="eyebrow">{page.eyebrow}</p>
           <h1>{page.title}</h1>
           <p className="marketing-intro">{page.intro}</p>
-          <a className="primary-button marketing-primary-cta" href="/">
+          <a
+            className="primary-button marketing-primary-cta"
+            href={roomHref}
+            onClick={() => recordGrowthEvent("marketing_cta_clicked", slug)}
+          >
             Create a disposable room
           </a>
         </header>
@@ -317,7 +320,11 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
             Set the message and room lifetime, issue a single-use invite, and destroy the room when
             you are finished.
           </p>
-          <a className="primary-button marketing-primary-cta" href="/">
+          <a
+            className="primary-button marketing-primary-cta"
+            href={roomHref}
+            onClick={() => recordGrowthEvent("marketing_cta_clicked", slug)}
+          >
             Open elm.chat
           </a>
         </footer>

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -1,0 +1,20 @@
+import type { MarketingAcquisitionSource } from "@elm-chat/shared";
+
+type ClientGrowthEvent = "make_your_own_clicked" | "marketing_cta_clicked";
+
+export function recordGrowthEvent(
+  event: ClientGrowthEvent,
+  source?: MarketingAcquisitionSource
+): void {
+  const body = JSON.stringify({ event, source });
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon("/api/growth", new Blob([body], { type: "application/json" }));
+    return;
+  }
+  void fetch("/api/growth", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+    keepalive: true
+  });
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,11 +16,29 @@ export const FILE_CHUNK_BYTES = 64 * 1024;
 
 export type RoomStatus = "open" | "expired" | "destroyed";
 
+export const ACQUISITION_SOURCES = [
+  "invite",
+  "self-destructing-chat",
+  "send-a-password-securely",
+  "one-time-secret-chat",
+  "building-ephemeral-chat-cloudflare"
+] as const;
+
+export type AcquisitionSource = (typeof ACQUISITION_SOURCES)[number];
+export type MarketingAcquisitionSource = Exclude<AcquisitionSource, "invite">;
+
+export function isAcquisitionSource(value: unknown): value is AcquisitionSource {
+  return (
+    typeof value === "string" &&
+    (ACQUISITION_SOURCES as readonly string[]).includes(value)
+  );
+}
+
 export interface CreateRoomRequest {
   disappearAfterReadSeconds?: number | null;
   inactivityTimeoutMs?: number | null;
   maxAgeMs?: number | null;
-  acquisitionSource?: "invite";
+  acquisitionSource?: AcquisitionSource;
   turnstileToken?: string;
 }
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_DISAPPEAR_AFTER_READ_SECONDS,
   DEFAULT_INACTIVITY_TIMEOUT_MS,
+  isAcquisitionSource,
   ROOM_ID_BYTES,
   type CreateRoomRequest,
   type CreateRoomResponse
@@ -16,7 +17,11 @@ type Env = {
   TURNSTILE_SECRET?: string;
 };
 
-type GrowthEvent = "make_your_own_clicked" | "room_created" | "invite_created";
+type GrowthEvent =
+  | "make_your_own_clicked"
+  | "marketing_cta_clicked"
+  | "room_created"
+  | "invite_created";
 
 function recordGrowth(env: Env, event: GrowthEvent, source = ""): void {
   env.GROWTH?.writeDataPoint({
@@ -160,7 +165,11 @@ async function handleCreateRoom(request: Request, env: Env): Promise<Response> {
     body: JSON.stringify(response)
   });
 
-  recordGrowth(env, "room_created", body.acquisitionSource === "invite" ? "invite" : "direct");
+  recordGrowth(
+    env,
+    "room_created",
+    isAcquisitionSource(body.acquisitionSource) ? body.acquisitionSource : "direct"
+  );
   return json(response, 201);
 }
 
@@ -261,12 +270,20 @@ function routeApi(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
 
   if (request.method === "POST" && url.pathname === "/api/growth") {
-    return safeJson<{ event?: string }>(request)
-      .then(({ event }) => {
-        if (event !== "make_your_own_clicked") {
+    return safeJson<{ event?: string; source?: string }>(request)
+      .then(({ event, source }) => {
+        if (event === "make_your_own_clicked") {
+          recordGrowth(env, event);
+          return new Response(null, { status: 204 });
+        }
+        if (
+          event !== "marketing_cta_clicked" ||
+          !isAcquisitionSource(source) ||
+          source === "invite"
+        ) {
           return json({ error: "Unsupported event." }, 400);
         }
-        recordGrowth(env, event);
+        recordGrowth(env, event, source);
         return new Response(null, { status: 204 });
       })
       .catch(() => json({ error: "Invalid event." }, 400));


### PR DESCRIPTION
Adds a fixed, privacy-safe acquisition-source model for the four public guides and the invite loop. Marketing CTAs now record aggregate click events and carry their source into room creation; the Worker validates every source against a closed allowlist before writing Analytics Engine events. The prerendered fallback also preserves attribution without inline scripts. No referrer, room ID, invite token, message, IP, or participant identifier is added. Verified with typecheck, production build, and two correctly attributed CTA links in every generated guide.