### PR TITLE
Complete the privacy-safe acquisition funnel

### DIFF
--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -267,6 +267,7 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
     const description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
     const previousDescription = description?.content ?? "";
 
+    recordGrowthEvent("marketing_page_viewed", slug);
     document.title = `${page.title} | elm.chat`;
     if (description) {
       description.content = page.description;
@@ -278,7 +279,7 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
         description.content = previousDescription;
       }
     };
-  }, [page]);
+  }, [page, slug]);
 
   return (
     <main className="marketing-shell">

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -1,6 +1,9 @@
 import type { MarketingAcquisitionSource } from "@elm-chat/shared";
 
-type ClientGrowthEvent = "make_your_own_clicked" | "marketing_cta_clicked";
+type ClientGrowthEvent =
+  | "make_your_own_clicked"
+  | "marketing_page_viewed"
+  | "marketing_cta_clicked";
 
 export function recordGrowthEvent(
   event: ClientGrowthEvent,

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -19,6 +19,7 @@ type Env = {
 
 type GrowthEvent =
   | "make_your_own_clicked"
+  | "marketing_page_viewed"
   | "marketing_cta_clicked"
   | "room_created"
   | "invite_created";
@@ -276,11 +277,9 @@ function routeApi(request: Request, env: Env): Promise<Response> {
           recordGrowth(env, event);
           return new Response(null, { status: 204 });
         }
-        if (
-          event !== "marketing_cta_clicked" ||
-          !isAcquisitionSource(source) ||
-          source === "invite"
-        ) {
+        const isMarketingEvent =
+          event === "marketing_page_viewed" || event === "marketing_cta_clicked";
+        if (!isMarketingEvent || !isAcquisitionSource(source) || source === "invite") {
           return json({ error: "Unsupported event." }, 400);
         }
         recordGrowth(env, event, source);


### PR DESCRIPTION
Adds an aggregate page-view event for each allowlisted acquisition guide, completing the page view → CTA click → room creation funnel per fixed campaign source. The event uses the same first-party Analytics Engine path and stores no referrer, URL query, room, invite, IP, participant, or message identifier. Verified with typecheck and production build.