### PR TITLE
Add temporary private chat acquisition page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
 
-Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), or explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare).
+Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), or explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare).
 
 ## Run your own in one click
 

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -13,6 +13,7 @@ const urls = [
   { path: "/self-destructing-chat", changefreq: "monthly", priority: "0.8" },
   { path: "/send-a-password-securely", changefreq: "monthly", priority: "0.8" },
   { path: "/one-time-secret-chat", changefreq: "monthly", priority: "0.8" },
+  { path: "/temporary-private-chat", changefreq: "monthly", priority: "0.8" },
   { path: "/building-ephemeral-chat-cloudflare", changefreq: "monthly", priority: "0.8" }
 ];
 

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -71,6 +71,35 @@ const pages = {
         <p>elm.chat encrypts message and file content in the browser and does not persist a server-side transcript. Its relay still observes connection metadata such as timing, sizes, IP addresses, and presence.</p>
       </section>`
   },
+  "temporary-private-chat": {
+    title: "Temporary private chat room without signup",
+    description:
+      "Create a short-lived private chat room in your browser, share a single-use invite, and end the conversation without an account or server-side transcript.",
+    eyebrow: "Temporary private chat",
+    intro:
+      "Sometimes you already know who you need to talk to—you just do not want to create an account, install an app, or leave the conversation in permanent history.",
+    body: `
+      <section>
+        <h2>A private link, not a room full of strangers</h2>
+        <p>Temporary chat can mean two very different things. Random chat services match you with unknown people. A private temporary room is created for people who already intend to talk and is reached through an invite you share directly.</p>
+        <p>elm.chat uses creator-issued, single-use invites. There is no public room directory, contact discovery, phone number, email address, or account profile.</p>
+      </section>
+      <section>
+        <h2>What happens to the conversation</h2>
+        <ul>
+          <li>Message and file content is encrypted in each participant's browser.</li>
+          <li>The relay coordinates the live room without persisting a server-side transcript.</li>
+          <li>The creator can set expiry rules, revoke unused invites, or destroy the room.</li>
+          <li>Participants can still copy, photograph, or otherwise retain what they receive.</li>
+        </ul>
+        <p>The relay can observe connection metadata such as IP addresses, timing, sizes, and presence. Temporary does not mean anonymous, and encryption does not protect a compromised device.</p>
+      </section>
+      <section>
+        <h2>When a temporary room is the right tool</h2>
+        <p>Use one for a one-off credential handoff, short client coordination, an event or marketplace meetup, or another conversation that needs live back-and-forth but not a permanent group.</p>
+        <p>For an ongoing relationship, a mature encrypted messenger is usually the better fit. For a single one-way value, a purpose-built one-time secret can be simpler.</p>
+      </section>`
+  },
   "building-ephemeral-chat-cloudflare": {
     title: "Building ephemeral encrypted chat with Cloudflare Durable Objects",
     description:
@@ -126,6 +155,7 @@ const guideLabels = {
   "self-destructing-chat": "What self-destructing chat should mean",
   "send-a-password-securely": "How to send a password securely",
   "one-time-secret-chat": "One-time secret vs disposable chat",
+  "temporary-private-chat": "Temporary private chat without signup",
   "building-ephemeral-chat-cloudflare": "How elm.chat works on Cloudflare"
 };
 

--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -6,6 +6,7 @@ const urlList = [
   `https://${host}/self-destructing-chat`,
   `https://${host}/send-a-password-securely`,
   `https://${host}/one-time-secret-chat`,
+  `https://${host}/temporary-private-chat`,
   `https://${host}/building-ephemeral-chat-cloudflare`
 ];
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -90,6 +90,7 @@ function roomPathname(): { view: View; roomId?: string; marketingSlug?: Marketin
     marketingSlug === "self-destructing-chat" ||
     marketingSlug === "send-a-password-securely" ||
     marketingSlug === "one-time-secret-chat" ||
+    marketingSlug === "temporary-private-chat" ||
     marketingSlug === "building-ephemeral-chat-cloudflare"
   ) {
     return { view: "marketing", marketingSlug };

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -149,6 +149,60 @@ const pages: Record<MarketingSlug, MarketingPageContent> = {
       </>
     )
   },
+  "temporary-private-chat": {
+    title: "Temporary private chat room without signup",
+    description:
+      "Create a short-lived private chat room in your browser, share a single-use invite, and end the conversation without an account or server-side transcript.",
+    eyebrow: "Temporary private chat",
+    intro:
+      "Sometimes you already know who you need to talk to—you just do not want to create an account, install an app, or leave the conversation in permanent history.",
+    body: (
+      <>
+        <section>
+          <h2>A private link, not a room full of strangers</h2>
+          <p>
+            Temporary chat can mean two very different things. Random chat services match you with
+            unknown people. A private temporary room is created for people who already intend to
+            talk and is reached through an invite you share directly.
+          </p>
+          <p>
+            elm.chat uses creator-issued, single-use invites. There is no public room directory,
+            contact discovery, phone number, email address, or account profile.
+          </p>
+        </section>
+
+        <section>
+          <h2>What happens to the conversation</h2>
+          <ul>
+            <li>Message and file content is encrypted in each participant&apos;s browser.</li>
+            <li>The relay coordinates the live room without persisting a server-side transcript.</li>
+            <li>The creator can set expiry rules, revoke unused invites, or destroy the room.</li>
+            <li>Participants can still copy, photograph, or otherwise retain what they receive.</li>
+          </ul>
+          <p>
+            The relay can observe connection metadata such as IP addresses, timing, sizes, and
+            presence. Temporary does not mean anonymous, and encryption does not protect a
+            compromised device.
+          </p>
+        </section>
+
+        <section>
+          <h2>When a temporary room is the right tool</h2>
+          <p>
+            Use one for a one-off credential handoff, short client coordination, an event or
+            marketplace meetup, or another conversation that needs live back-and-forth but not a
+            permanent group.
+          </p>
+          <p>
+            For an ongoing relationship, a mature encrypted messenger is usually the better fit.
+            For a single one-way value, a purpose-built one-time secret can be simpler.
+          </p>
+        </section>
+
+        <Limitations />
+      </>
+    )
+  },
   "building-ephemeral-chat-cloudflare": {
     title: "Building ephemeral encrypted chat with Cloudflare Durable Objects",
     description:
@@ -339,6 +393,7 @@ function RelatedGuides({ current }: { current: MarketingSlug }) {
     { slug: "self-destructing-chat", label: "What self-destructing chat should mean" },
     { slug: "send-a-password-securely", label: "How to send a password securely" },
     { slug: "one-time-secret-chat", label: "One-time secret vs disposable chat" },
+    { slug: "temporary-private-chat", label: "Temporary private chat without signup" },
     {
       slug: "building-ephemeral-chat-cloudflare",
       label: "How elm.chat works on Cloudflare"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,7 @@ export const ACQUISITION_SOURCES = [
   "self-destructing-chat",
   "send-a-password-securely",
   "one-time-secret-chat",
+  "temporary-private-chat",
   "building-ephemeral-chat-cloudflare"
 ] as const;
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -227,6 +227,7 @@ const MARKETING_PATHS = new Set([
   "/self-destructing-chat",
   "/send-a-password-securely",
   "/one-time-secret-chat",
+  "/temporary-private-chat",
   "/building-ephemeral-chat-cloudflare"
 ]);
 


### PR DESCRIPTION
## Summary

- publish a prerendered `/temporary-private-chat` acquisition page targeting private, no-signup room intent
- distinguish invite-only rooms from random stranger chat without overstating anonymity or security
- add privacy-safe page-view, CTA, and room-creation attribution through the closed source allowlist
- include the page in related guides, README discovery, sitemap, IndexNow, and canonical routing

## Validation

- `npm run typecheck`
- `npm run build`
- `git diff --check`
- inspected prerendered canonical, title, source attribution, and sitemap entry

The repository has no root test script.
