### PR TITLE
Add structured data for search discovery

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -23,6 +23,41 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="elm.chat — One conversation. Then gone." />
     <meta name="twitter:card" content="summary_large_image" />
+    <script id="structured-data" type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "https://elm.chat/#website",
+            "url": "https://elm.chat/",
+            "name": "elm.chat",
+            "alternateName": "elm chat",
+            "description": "Disposable encrypted chat rooms with no accounts, single-use invites, and no server-side transcript."
+          },
+          {
+            "@type": "WebApplication",
+            "@id": "https://elm.chat/#application",
+            "url": "https://elm.chat/",
+            "name": "elm.chat",
+            "description": "Create a disposable encrypted chat room with no account, single-use invites, and no server-side transcript.",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Any modern web browser",
+            "browserRequirements": "JavaScript and Web Crypto support",
+            "isAccessibleForFree": true,
+            "offers": {
+              "@type": "Offer",
+              "price": 0,
+              "priceCurrency": "USD"
+            },
+            "image": "https://elm.chat/elm-chat-social.png",
+            "codeRepository": "https://github.com/shawnbure/elm-chat",
+            "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+            "sameAs": ["https://github.com/shawnbure/elm-chat"]
+          }
+        ]
+      }
+    </script>
     <title>elm chat</title>
   </head>
   <body>

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -161,6 +161,36 @@ const guideLabels = {
 
 for (const [slug, page] of Object.entries(pages)) {
   const canonical = `${ORIGIN}/${slug}`;
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: page.title,
+    description: page.description,
+    image: [`${ORIGIN}/elm-chat-social.png`],
+    datePublished: "2026-07-28",
+    dateModified: "2026-07-28",
+    author: {
+      "@type": "Organization",
+      name: "elm.chat",
+      url: `${ORIGIN}/`
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "elm.chat",
+      url: `${ORIGIN}/`
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": canonical
+    },
+    isPartOf: {
+      "@type": "WebSite",
+      "@id": `${ORIGIN}/#website`,
+      name: "elm.chat",
+      url: `${ORIGIN}/`
+    }
+  };
+  const structuredDataScript = `<script id="structured-data" type="application/ld+json">${JSON.stringify(structuredData).replace(/</g, "\\u003c")}</script>`;
   const content = `
     <main class="marketing-shell">
       <nav class="marketing-nav" aria-label="elm.chat">
@@ -227,6 +257,10 @@ for (const [slug, page] of Object.entries(pages)) {
     .replace(
       /<meta property="og:url" content="[^"]*" \/>/,
       `<meta property="og:url" content="${canonical}" />`
+    )
+    .replace(
+      /<script id="structured-data" type="application\/ld\+json">[\s\S]*?<\/script>/,
+      structuredDataScript
     )
     .replace('<div id="root"></div>', `<div id="root">${content}</div>`);
 


### PR DESCRIPTION
## Summary

- describe the homepage as a WebSite and free WebApplication using JSON-LD
- describe each prerendered guide as an Article with canonical URL, image, publication date, and publisher
- omit ratings and reviews rather than fabricating rich-result eligibility
- replace homepage schema with page-specific Article schema during prerendering

## Validation

- `npm run typecheck`
- `npm run build`
- parsed JSON-LD from the homepage and all five generated guide files
- `git diff --check`

Based on current Google Search Central structured-data and Article/SoftwareApplication guidance.
