### PR TITLE
Remove unsupported app schema property

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -51,7 +51,6 @@
               "priceCurrency": "USD"
             },
             "image": "https://elm.chat/elm-chat-social.png",
-            "codeRepository": "https://github.com/shawnbure/elm-chat",
             "license": "https://www.gnu.org/licenses/agpl-3.0.html",
             "sameAs": ["https://github.com/shawnbure/elm-chat"]
           }


### PR DESCRIPTION
Schema.org validation reported `codeRepository` as unsupported on `WebApplication`. The repository is already represented by the valid `sameAs` property, so remove the redundant field.

Validated with the web production build and JSON parsing; live Schema.org validation will rerun after deployment.
