### PR TITLE
Add Durable Objects WebSocket hibernation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
 
-Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), or explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare).
+Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare), or see how [WebSocket hibernation works without a chat database](https://elm.chat/durable-objects-websocket-hibernation).
 
 ## Run your own in one click
 

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -14,7 +14,8 @@ const urls = [
   { path: "/send-a-password-securely", changefreq: "monthly", priority: "0.8" },
   { path: "/one-time-secret-chat", changefreq: "monthly", priority: "0.8" },
   { path: "/temporary-private-chat", changefreq: "monthly", priority: "0.8" },
-  { path: "/building-ephemeral-chat-cloudflare", changefreq: "monthly", priority: "0.8" }
+  { path: "/building-ephemeral-chat-cloudflare", changefreq: "monthly", priority: "0.8" },
+  { path: "/durable-objects-websocket-hibernation", changefreq: "monthly", priority: "0.8" }
 ];
 
 const lastmod = new Date().toISOString().slice(0, 10);

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -147,6 +147,62 @@ const pages = {
         <p>The complete TypeScript project is AGPL-3.0 licensed. The repository includes the architecture, threat model, deployment instructions, contributor guide, and a one-click Cloudflare deploy path.</p>
         <p><a href="https://github.com/shawnbure/elm-chat">Read the source and deployment guide</a>.</p>
       </section>`
+  },
+  "durable-objects-websocket-hibernation": {
+    title: "Durable Objects WebSocket hibernation without a chat database",
+    description:
+      "How elm.chat uses Cloudflare Durable Objects WebSocket hibernation, serialized socket attachments, client-held encrypted history, and peer sync without storing a server transcript.",
+    eyebrow: "Durable Objects deep dive",
+    intro:
+      "WebSocket hibernation can keep a room reachable while its Durable Object sleeps. It does not preserve ordinary JavaScript memory, so elm.chat separates durable room state, live connection identity, and disposable message history.",
+    body: `
+      <section>
+        <h2>Three kinds of state, three different homes</h2>
+        <ul>
+          <li><strong>Durable room state:</strong> expiry policy, creator capability, room status, and one-time invite records live in Durable Object storage.</li>
+          <li><strong>Live connection state:</strong> session ID, creator role, identity key, and connection time live in each WebSocket's serialized attachment.</li>
+          <li><strong>Conversation history:</strong> encrypted message envelopes remain in connected browsers and are not written to Durable Object storage.</li>
+        </ul>
+        <p>This split is the core design choice. Hibernation can discard the object's process-local memory, but the object can reload durable metadata and enumerate accepted sockets when it wakes.</p>
+      </section>
+      <section>
+        <h2>Make socket attachments the membership source of truth</h2>
+        <p>The room accepts a socket with <code>acceptWebSocket</code>, then writes a small attachment with <code>serializeAttachment</code>. After a wake-up, routing code calls <code>getWebSockets</code> and <code>deserializeAttachment</code> instead of trusting an in-memory participant map.</p>
+        <pre><code>this.ctx.acceptWebSocket(server);
+server.serializeAttachment({
+  sessionId: "",
+  creator: false,
+  identityKey: "",
+  connectedAt: 0
+});</code></pre>
+        <p>The empty session ID marks an accepted socket that has not completed its authenticated join. Once the creator capability or one-time invite is validated, the attachment is replaced with the joined session record.</p>
+      </section>
+      <section>
+        <h2>Rebuild presence by enumerating live sockets</h2>
+        <p>Presence, targeted relay, participant removal, and room capacity all derive from the current socket set. Duplicate session IDs are collapsed before the room announces its membership count.</p>
+        <p>Durable storage still records public room metadata, but it is not treated as the authority for who is connected at this instant. That avoids restoring a stale participant map after hibernation.</p>
+      </section>
+      <section>
+        <h2>Let clients supply encrypted history</h2>
+        <p>A joining browser sends a <code>sync_request</code> through the relay. Connected peers answer with at most the latest 200 encrypted message envelopes. The Durable Object routes that payload but never commits it to storage.</p>
+        <p>This deliberately gives up server-backed recovery. If every browser that held an item disconnects, a later participant cannot retrieve it. A malicious peer can also omit or reorder sync data, and message authentication is not implemented yet.</p>
+      </section>
+      <section>
+        <h2>What hibernation does—and does not—buy</h2>
+        <ul>
+          <li>The object can sleep while accepted WebSockets remain attached to the room.</li>
+          <li>Connection identity survives through serialized attachments, not class fields.</li>
+          <li>Room policy survives because it is stored and reloaded during initialization.</li>
+          <li>Message history stays disposable because connected clients, not storage, hold it.</li>
+          <li>Cloudflare still observes normal connection metadata and relayed payload sizes.</li>
+        </ul>
+        <p>This is not a general recipe for durable chat. It is a tradeoff for a room where losing history is preferable to turning the relay into an archive.</p>
+      </section>
+      <section>
+        <h2>Inspect the implementation</h2>
+        <p>The complete TypeScript implementation, room protocol, tests, threat model, and Cloudflare deployment path are available under AGPL-3.0.</p>
+        <p><a href="https://github.com/shawnbure/elm-chat/blob/main/durable-objects/room/src/room.ts">Read the Durable Object source</a>.</p>
+      </section>`
   }
 };
 
@@ -156,7 +212,8 @@ const guideLabels = {
   "send-a-password-securely": "How to send a password securely",
   "one-time-secret-chat": "One-time secret vs disposable chat",
   "temporary-private-chat": "Temporary private chat without signup",
-  "building-ephemeral-chat-cloudflare": "How elm.chat works on Cloudflare"
+  "building-ephemeral-chat-cloudflare": "How elm.chat works on Cloudflare",
+  "durable-objects-websocket-hibernation": "WebSocket hibernation without a chat database"
 };
 
 for (const [slug, page] of Object.entries(pages)) {

--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -7,7 +7,8 @@ const urlList = [
   `https://${host}/send-a-password-securely`,
   `https://${host}/one-time-secret-chat`,
   `https://${host}/temporary-private-chat`,
-  `https://${host}/building-ephemeral-chat-cloudflare`
+  `https://${host}/building-ephemeral-chat-cloudflare`,
+  `https://${host}/durable-objects-websocket-hibernation`
 ];
 
 const response = await fetch("https://api.indexnow.org/indexnow", {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -91,7 +91,8 @@ function roomPathname(): { view: View; roomId?: string; marketingSlug?: Marketin
     marketingSlug === "send-a-password-securely" ||
     marketingSlug === "one-time-secret-chat" ||
     marketingSlug === "temporary-private-chat" ||
-    marketingSlug === "building-ephemeral-chat-cloudflare"
+    marketingSlug === "building-ephemeral-chat-cloudflare" ||
+    marketingSlug === "durable-objects-websocket-hibernation"
   ) {
     return { view: "marketing", marketingSlug };
   }

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -294,6 +294,127 @@ const pages: Record<MarketingSlug, MarketingPageContent> = {
         <Limitations />
       </>
     )
+  },
+  "durable-objects-websocket-hibernation": {
+    title: "Durable Objects WebSocket hibernation without a chat database",
+    description:
+      "How elm.chat uses Cloudflare Durable Objects WebSocket hibernation, serialized socket attachments, client-held encrypted history, and peer sync without storing a server transcript.",
+    eyebrow: "Durable Objects deep dive",
+    intro:
+      "WebSocket hibernation can keep a room reachable while its Durable Object sleeps. It does not preserve ordinary JavaScript memory, so elm.chat separates durable room state, live connection identity, and disposable message history.",
+    body: (
+      <>
+        <section>
+          <h2>Three kinds of state, three different homes</h2>
+          <ul>
+            <li>
+              <strong>Durable room state:</strong> expiry policy, creator capability, room status,
+              and one-time invite records live in Durable Object storage.
+            </li>
+            <li>
+              <strong>Live connection state:</strong> session ID, creator role, identity key, and
+              connection time live in each WebSocket&apos;s serialized attachment.
+            </li>
+            <li>
+              <strong>Conversation history:</strong> encrypted message envelopes remain in connected
+              browsers and are not written to Durable Object storage.
+            </li>
+          </ul>
+          <p>
+            This split is the core design choice. Hibernation can discard the object&apos;s
+            process-local memory, but the object can reload durable metadata and enumerate accepted
+            sockets when it wakes.
+          </p>
+        </section>
+
+        <section>
+          <h2>Make socket attachments the membership source of truth</h2>
+          <p>
+            The room accepts a socket with <code>acceptWebSocket</code>, then writes a small
+            attachment with <code>serializeAttachment</code>. After a wake-up, routing code calls{" "}
+            <code>getWebSockets</code> and <code>deserializeAttachment</code> instead of trusting an
+            in-memory participant map.
+          </p>
+          <pre>
+            <code>{`this.ctx.acceptWebSocket(server);
+server.serializeAttachment({
+  sessionId: "",
+  creator: false,
+  identityKey: "",
+  connectedAt: 0
+});`}</code>
+          </pre>
+          <p>
+            The empty session ID marks an accepted socket that has not completed its authenticated
+            join. Once the creator capability or one-time invite is validated, the attachment is
+            replaced with the joined session record.
+          </p>
+        </section>
+
+        <section>
+          <h2>Rebuild presence by enumerating live sockets</h2>
+          <p>
+            Presence, targeted relay, participant removal, and room capacity all derive from the
+            current socket set. Duplicate session IDs are collapsed before the room announces its
+            membership count.
+          </p>
+          <p>
+            Durable storage still records public room metadata, but it is not treated as the
+            authority for who is connected at this instant. That avoids restoring a stale
+            participant map after hibernation.
+          </p>
+        </section>
+
+        <section>
+          <h2>Let clients supply encrypted history</h2>
+          <p>
+            A joining browser sends a <code>sync_request</code> through the relay. Connected peers
+            answer with at most the latest 200 encrypted message envelopes. The Durable Object
+            routes that payload but never commits it to storage.
+          </p>
+          <p>
+            This deliberately gives up server-backed recovery. If every browser that held an item
+            disconnects, a later participant cannot retrieve it. A malicious peer can also omit or
+            reorder sync data, and message authentication is not implemented yet.
+          </p>
+        </section>
+
+        <section>
+          <h2>What hibernation does—and does not—buy</h2>
+          <ul>
+            <li>The object can sleep while accepted WebSockets remain attached to the room.</li>
+            <li>Connection identity survives through serialized attachments, not class fields.</li>
+            <li>Room policy survives because it is stored and reloaded during initialization.</li>
+            <li>Message history stays disposable because connected clients, not storage, hold it.</li>
+            <li>Cloudflare still observes normal connection metadata and relayed payload sizes.</li>
+          </ul>
+          <p>
+            This is not a general recipe for durable chat. It is a tradeoff for a room where losing
+            history is preferable to turning the relay into an archive.
+          </p>
+        </section>
+
+        <section>
+          <h2>Inspect the implementation</h2>
+          <p>
+            The complete TypeScript implementation, room protocol, tests, threat model, and
+            Cloudflare deployment path are available under AGPL-3.0.
+          </p>
+          <p>
+            <a
+              href={`${GITHUB_URL}/blob/main/durable-objects/room/src/room.ts`}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Read the Durable Object source
+            </a>
+            .
+          </p>
+        </section>
+
+        <Limitations />
+      </>
+    )
   }
 };
 
@@ -397,6 +518,10 @@ function RelatedGuides({ current }: { current: MarketingSlug }) {
     {
       slug: "building-ephemeral-chat-cloudflare",
       label: "How elm.chat works on Cloudflare"
+    },
+    {
+      slug: "durable-objects-websocket-hibernation",
+      label: "WebSocket hibernation without a chat database"
     }
   ];
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1044,6 +1044,34 @@ select {
   padding-left: 1.4rem;
 }
 
+.marketing-body code {
+  padding: 0.12em 0.34em;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.04);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+}
+
+.marketing-body pre {
+  max-width: 100%;
+  margin: 0;
+  padding: 18px 20px;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(8, 18, 16, 0.94);
+  color: #eff8f5;
+  line-height: 1.55;
+}
+
+.marketing-body pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+}
+
 .marketing-caveat {
   padding: 22px 24px;
   border-radius: 20px;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,7 +22,8 @@ export const ACQUISITION_SOURCES = [
   "send-a-password-securely",
   "one-time-secret-chat",
   "temporary-private-chat",
-  "building-ephemeral-chat-cloudflare"
+  "building-ephemeral-chat-cloudflare",
+  "durable-objects-websocket-hibernation"
 ] as const;
 
 export type AcquisitionSource = (typeof ACQUISITION_SOURCES)[number];

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -228,7 +228,8 @@ const MARKETING_PATHS = new Set([
   "/send-a-password-securely",
   "/one-time-secret-chat",
   "/temporary-private-chat",
-  "/building-ephemeral-chat-cloudflare"
+  "/building-ephemeral-chat-cloudflare",
+  "/durable-objects-websocket-hibernation"
 ]);
 
 // Cached in the isolate so repeated visitors don't each trigger a GitHub call.


### PR DESCRIPTION
## Summary
- publish a focused guide to WebSocket hibernation and serialized socket attachments
- explain elm.chat’s split between durable room metadata, live connection state, and client-held encrypted history
- add the guide to routing, prerendering, sitemap, IndexNow, related guides, README, and privacy-safe acquisition attribution

## Verification
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Security claims
The guide explicitly states that Cloudflare observes connection metadata, recipients can retain plaintext, message authentication is incomplete, and elm.chat has not had an independent security audit.