### PR TITLE
Publish the elm.chat founder story

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
 
-Try [elm.chat](https://elm.chat), read what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare), or see how [WebSocket hibernation works without a chat database](https://elm.chat/durable-objects-websocket-hibernation).
+Try [elm.chat](https://elm.chat), read [why I built a messenger designed to disappear](https://elm.chat/why-i-built-elm-chat), learn what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare), or see how [WebSocket hibernation works without a chat database](https://elm.chat/durable-objects-websocket-hibernation).
 
 ## Run your own in one click
 

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -14,6 +14,7 @@ const urls = [
   { path: "/send-a-password-securely", changefreq: "monthly", priority: "0.8" },
   { path: "/one-time-secret-chat", changefreq: "monthly", priority: "0.8" },
   { path: "/temporary-private-chat", changefreq: "monthly", priority: "0.8" },
+  { path: "/why-i-built-elm-chat", changefreq: "monthly", priority: "0.7" },
   { path: "/building-ephemeral-chat-cloudflare", changefreq: "monthly", priority: "0.8" },
   { path: "/durable-objects-websocket-hibernation", changefreq: "monthly", priority: "0.8" }
 ];

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -128,6 +128,46 @@ const pages = {
         <p>For an ongoing relationship, a mature encrypted messenger is usually the better fit. For a single one-way value, a purpose-built one-time secret can be simpler.</p>
       </section>`
   },
+  "why-i-built-elm-chat": {
+    title: "Why I built a messenger designed to disappear",
+    description:
+      "Workrr founder Shawn Bure explains why he built elm.chat: an open-source disposable room for conversations that should not become permanent records.",
+    eyebrow: "Founder's note",
+    byline: "By Shawn Bure — founder of Workrr AI and Workrr One",
+    authorName: "Shawn Bure",
+    authorUrl: "https://www.workrr.ai/",
+    datePublished: "2026-08-03",
+    dateModified: "2026-08-03",
+    intro:
+      "After decades of building operational, financial, communications, and AI systems, I wanted to build one system whose most important feature was knowing when not to remember.",
+    body: `
+      <section>
+        <h2>Most software is rewarded for remembering everything</h2>
+        <p>I have spent much of my career turning difficult, fragmented work into systems people can actually operate. I built and scaled a national recovery operation, founded and sold the collections platform OpenCollect, and shipped software across payments, telephony, CRM, integrations, and cloud infrastructure. Today I lead Workrr AI and Workrr One, where the work is making production AI useful, governed, and accountable.</p>
+        <p>In all of those systems, memory has value. Records make work measurable. Evidence makes decisions reviewable. History helps a process improve. But the same instinct applied to every human interaction creates a different problem: a ten-second exchange becomes a permanent artifact scattered across inboxes, chat histories, backups, and devices.</p>
+      </section>
+      <section>
+        <h2>Some conversations deserve a smaller footprint</h2>
+        <p>Sometimes two people need to exchange a credential, resolve a sensitive operational question, or coordinate something private without adopting another social network. They already know whom they need to reach. What they need is a link for one conversation, not another identity, contact list, notification stream, or archive.</p>
+        <p>That is the idea behind elm.chat. A person creates a room without an account, sends a single-use invite, talks live, and destroys the room when the job is done. The goal is not to replace a mature messenger. It is to make a narrow, disposable channel easy enough to reach for at the moment it is useful.</p>
+      </section>
+      <section>
+        <h2>Privacy should be an architecture, not an adjective</h2>
+        <p>elm.chat encrypts messages and files in participants' browsers. The room secret stays in the URL fragment during normal use, and the Cloudflare relay coordinates the live room without persisting a server-side transcript. Room policy and invite state exist; the conversation itself is held by connected clients and is intentionally disposable.</p>
+        <p>The project is AGPL-3.0, so anyone can inspect it, challenge its choices, or run a copy. I published the architecture and threat model because trust should come from evidence and scrutiny—not from a lock icon or a founder saying “secure.”</p>
+      </section>
+      <section>
+        <h2>Honesty matters more than a perfect privacy story</h2>
+        <p>elm.chat has not had an independent security audit. Message authentication is not yet complete. Cloudflare can observe ordinary relay metadata such as IP addresses, timing, sizes, and presence. A compromised device, screenshot, clipboard manager, photograph, or malicious recipient can preserve what the room was designed to forget.</p>
+        <p>Those are not footnotes to hide after adoption. They define where the tool fits. I do not want people in high-risk situations to confuse an experimental open-source product with an audited anonymity system. I want engineers and privacy practitioners to inspect it, improve it, and help make its claims narrower and stronger.</p>
+      </section>
+      <section>
+        <h2>The larger idea I want to put into the world</h2>
+        <p>Workrr One asks how AI systems can remain accountable: explicit permissions, human approval, bounded retention, reproducible releases, and evidence of what happened. elm.chat asks the complementary question: when does responsible software mean creating less evidence in the first place?</p>
+        <p>I want technology to give ordinary people more control over that boundary. Some work must be recorded. Some decisions must be auditable. Some conversations should simply accomplish their purpose and end. Software should be capable of telling the difference.</p>
+        <p>If that idea resonates, try elm.chat with non-critical information, read the source and threat model, open an issue, or deploy your own copy. The most useful contribution is not praise. It is evidence that helps make the boundary more honest.</p>
+      </section>`
+  },
   "building-ephemeral-chat-cloudflare": {
     title: "Building ephemeral encrypted chat with Cloudflare Durable Objects",
     description:
@@ -240,6 +280,7 @@ const guideLabels = {
   "send-a-password-securely": "How to send a password securely",
   "one-time-secret-chat": "One-time secret vs disposable chat",
   "temporary-private-chat": "Temporary private chat without signup",
+  "why-i-built-elm-chat": "Why I built elm.chat",
   "building-ephemeral-chat-cloudflare": "How elm.chat works on Cloudflare",
   "durable-objects-websocket-hibernation": "WebSocket hibernation without a chat database"
 };
@@ -252,13 +293,19 @@ for (const [slug, page] of Object.entries(pages)) {
     headline: page.title,
     description: page.description,
     image: [`${ORIGIN}/elm-chat-social.png`],
-    datePublished: "2026-07-28",
+    datePublished: page.datePublished ?? "2026-07-28",
     dateModified: page.dateModified ?? "2026-07-28",
-    author: {
-      "@type": "Organization",
-      name: "elm.chat",
-      url: `${ORIGIN}/`
-    },
+    author: page.authorName
+      ? {
+          "@type": "Person",
+          name: page.authorName,
+          url: page.authorUrl
+        }
+      : {
+          "@type": "Organization",
+          name: "elm.chat",
+          url: `${ORIGIN}/`
+        },
     publisher: {
       "@type": "Organization",
       name: "elm.chat",
@@ -289,6 +336,7 @@ for (const [slug, page] of Object.entries(pages)) {
         <header>
           <p class="eyebrow">${page.eyebrow}</p>
           <h1>${page.title}</h1>
+          ${page.byline ? `<p class="marketing-byline">${page.byline}</p>` : ""}
           <p class="marketing-intro">${page.intro}</p>
           <a class="primary-button marketing-primary-cta" href="/?source=${slug}">Create a disposable room</a>
         </header>

--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -7,6 +7,7 @@ const urlList = [
   `https://${host}/send-a-password-securely`,
   `https://${host}/one-time-secret-chat`,
   `https://${host}/temporary-private-chat`,
+  `https://${host}/why-i-built-elm-chat`,
   `https://${host}/building-ephemeral-chat-cloudflare`,
   `https://${host}/durable-objects-websocket-hibernation`
 ];

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -91,6 +91,7 @@ function roomPathname(): { view: View; roomId?: string; marketingSlug?: Marketin
     marketingSlug === "send-a-password-securely" ||
     marketingSlug === "one-time-secret-chat" ||
     marketingSlug === "temporary-private-chat" ||
+    marketingSlug === "why-i-built-elm-chat" ||
     marketingSlug === "building-ephemeral-chat-cloudflare" ||
     marketingSlug === "durable-objects-websocket-hibernation"
   ) {

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -8,6 +8,7 @@ const THREAT_MODEL_URL = `${GITHUB_URL}/blob/main/docs/threat-model.md`;
 export type MarketingSlug = MarketingAcquisitionSource;
 
 type MarketingPageContent = {
+  byline?: string;
   description: string;
   eyebrow: string;
   title: string;
@@ -253,6 +254,104 @@ const pages: Record<MarketingSlug, MarketingPageContent> = {
           <p>
             For an ongoing relationship, a mature encrypted messenger is usually the better fit.
             For a single one-way value, a purpose-built one-time secret can be simpler.
+          </p>
+        </section>
+
+        <Limitations />
+      </>
+    )
+  },
+  "why-i-built-elm-chat": {
+    title: "Why I built a messenger designed to disappear",
+    description:
+      "Workrr founder Shawn Bure explains why he built elm.chat: an open-source disposable room for conversations that should not become permanent records.",
+    eyebrow: "Founder's note",
+    byline: "By Shawn Bure — founder of Workrr AI and Workrr One",
+    intro:
+      "After decades of building operational, financial, communications, and AI systems, I wanted to build one system whose most important feature was knowing when not to remember.",
+    body: (
+      <>
+        <section>
+          <h2>Most software is rewarded for remembering everything</h2>
+          <p>
+            I have spent much of my career turning difficult, fragmented work into systems people
+            can actually operate. I built and scaled a national recovery operation, founded and sold
+            the collections platform OpenCollect, and shipped software across payments, telephony,
+            CRM, integrations, and cloud infrastructure. Today I lead Workrr AI and Workrr One,
+            where the work is making production AI useful, governed, and accountable.
+          </p>
+          <p>
+            In all of those systems, memory has value. Records make work measurable. Evidence makes
+            decisions reviewable. History helps a process improve. But the same instinct applied to
+            every human interaction creates a different problem: a ten-second exchange becomes a
+            permanent artifact scattered across inboxes, chat histories, backups, and devices.
+          </p>
+        </section>
+
+        <section>
+          <h2>Some conversations deserve a smaller footprint</h2>
+          <p>
+            Sometimes two people need to exchange a credential, resolve a sensitive operational
+            question, or coordinate something private without adopting another social network.
+            They already know whom they need to reach. What they need is a link for one conversation,
+            not another identity, contact list, notification stream, or archive.
+          </p>
+          <p>
+            That is the idea behind elm.chat. A person creates a room without an account, sends a
+            single-use invite, talks live, and destroys the room when the job is done. The goal is
+            not to replace a mature messenger. It is to make a narrow, disposable channel easy
+            enough to reach for at the moment it is useful.
+          </p>
+        </section>
+
+        <section>
+          <h2>Privacy should be an architecture, not an adjective</h2>
+          <p>
+            elm.chat encrypts messages and files in participants&apos; browsers. The room secret stays
+            in the URL fragment during normal use, and the Cloudflare relay coordinates the live
+            room without persisting a server-side transcript. Room policy and invite state exist;
+            the conversation itself is held by connected clients and is intentionally disposable.
+          </p>
+          <p>
+            The project is AGPL-3.0, so anyone can inspect it, challenge its choices, or run a copy.
+            I published the architecture and threat model because trust should come from evidence
+            and scrutiny—not from a lock icon or a founder saying “secure.”
+          </p>
+        </section>
+
+        <section>
+          <h2>Honesty matters more than a perfect privacy story</h2>
+          <p>
+            elm.chat has not had an independent security audit. Message authentication is not yet
+            complete. Cloudflare can observe ordinary relay metadata such as IP addresses, timing,
+            sizes, and presence. A compromised device, screenshot, clipboard manager, photograph,
+            or malicious recipient can preserve what the room was designed to forget.
+          </p>
+          <p>
+            Those are not footnotes to hide after adoption. They define where the tool fits. I do
+            not want people in high-risk situations to confuse an experimental open-source product
+            with an audited anonymity system. I want engineers and privacy practitioners to inspect
+            it, improve it, and help make its claims narrower and stronger.
+          </p>
+        </section>
+
+        <section>
+          <h2>The larger idea I want to put into the world</h2>
+          <p>
+            Workrr One asks how AI systems can remain accountable: explicit permissions, human
+            approval, bounded retention, reproducible releases, and evidence of what happened.
+            elm.chat asks the complementary question: when does responsible software mean creating
+            less evidence in the first place?
+          </p>
+          <p>
+            I want technology to give ordinary people more control over that boundary. Some work
+            must be recorded. Some decisions must be auditable. Some conversations should simply
+            accomplish their purpose and end. Software should be capable of telling the difference.
+          </p>
+          <p>
+            If that idea resonates, try elm.chat with non-critical information, read the source and
+            threat model, open an issue, or deploy your own copy. The most useful contribution is not
+            praise. It is evidence that helps make the boundary more honest.
           </p>
         </section>
 
@@ -533,6 +632,7 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
         <header>
           <p className="eyebrow">{page.eyebrow}</p>
           <h1>{page.title}</h1>
+          {page.byline ? <p className="marketing-byline">{page.byline}</p> : null}
           <p className="marketing-intro">{page.intro}</p>
           <a
             className="primary-button marketing-primary-cta"
@@ -572,6 +672,7 @@ function RelatedGuides({ current }: { current: MarketingSlug }) {
     { slug: "send-a-password-securely", label: "How to send a password securely" },
     { slug: "one-time-secret-chat", label: "One-time secret vs disposable chat" },
     { slug: "temporary-private-chat", label: "Temporary private chat without signup" },
+    { slug: "why-i-built-elm-chat", label: "Why I built elm.chat" },
     {
       slug: "building-ephemeral-chat-cloudflare",
       label: "How elm.chat works on Cloudflare"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -997,6 +997,13 @@ select {
   line-height: 1.6;
 }
 
+.marketing-byline {
+  margin: 18px 0 -8px;
+  color: var(--ink);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
 .marketing-primary-cta {
   display: inline-flex;
   align-items: center;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,6 +22,7 @@ export const ACQUISITION_SOURCES = [
   "send-a-password-securely",
   "one-time-secret-chat",
   "temporary-private-chat",
+  "why-i-built-elm-chat",
   "building-ephemeral-chat-cloudflare",
   "durable-objects-websocket-hibernation"
 ] as const;

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -255,6 +255,7 @@ const MARKETING_PATHS = new Set([
   "/send-a-password-securely",
   "/one-time-secret-chat",
   "/temporary-private-chat",
+  "/why-i-built-elm-chat",
   "/building-ephemeral-chat-cloudflare",
   "/durable-objects-websocket-hibernation"
 ]);


### PR DESCRIPTION
## Summary

- publish Shawn Bure’s first-person founder story about building software that knows when not to remember
- connect elm.chat’s disposable-room design to Workrr AI and Workrr One’s governed-technology philosophy
- disclose the missing independent audit, incomplete message authentication, relay metadata, and recipient/device limits
- add person-authored Article structured data, acquisition attribution, sitemap/IndexNow coverage, related-guide links, and a README entry

## Verification

- `npm run typecheck`
- `npm run build`
- `git diff --check`
- verified prerendered content, canonical URL, byline, Person author schema, and `2026-08-03` publish/modified dates