### PR TITLE
Track source interest from marketing pages

### DIFF
--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -634,13 +634,24 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
           <h1>{page.title}</h1>
           {page.byline ? <p className="marketing-byline">{page.byline}</p> : null}
           <p className="marketing-intro">{page.intro}</p>
-          <a
-            className="primary-button marketing-primary-cta"
-            href={roomHref}
-            onClick={() => recordGrowthEvent("marketing_cta_clicked", slug)}
-          >
-            Create a disposable room
-          </a>
+          <div className="marketing-header-actions">
+            <a
+              className="primary-button marketing-primary-cta"
+              href={roomHref}
+              onClick={() => recordGrowthEvent("marketing_cta_clicked", slug)}
+            >
+              Create a disposable room
+            </a>
+            <a
+              className="secondary-button marketing-source-cta"
+              href={GITHUB_URL}
+              rel="noreferrer"
+              target="_blank"
+              onClick={() => recordGrowthEvent("marketing_source_clicked", slug)}
+            >
+              Inspect the source
+            </a>
+          </div>
         </header>
 
         <div className="marketing-body">{page.body}</div>

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -3,7 +3,8 @@ import type { MarketingAcquisitionSource } from "@elm-chat/shared";
 type ClientGrowthEvent =
   | "make_your_own_clicked"
   | "marketing_page_viewed"
-  | "marketing_cta_clicked";
+  | "marketing_cta_clicked"
+  | "marketing_source_clicked";
 
 export function recordGrowthEvent(
   event: ClientGrowthEvent,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1012,6 +1012,20 @@ select {
   text-decoration: none;
 }
 
+.marketing-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.marketing-header-actions .marketing-primary-cta,
+.marketing-source-cta {
+  margin-top: 0;
+  text-decoration: none;
+}
+
 .marketing-body {
   display: grid;
   gap: 42px;

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -21,6 +21,7 @@ type GrowthEvent =
   | "make_your_own_clicked"
   | "marketing_page_viewed"
   | "marketing_cta_clicked"
+  | "marketing_source_clicked"
   | "room_created"
   | "invite_created";
 
@@ -308,7 +309,9 @@ function routeApi(request: Request, env: Env): Promise<Response> {
           return new Response(null, { status: 204 });
         }
         const isMarketingEvent =
-          event === "marketing_page_viewed" || event === "marketing_cta_clicked";
+          event === "marketing_page_viewed" ||
+          event === "marketing_cta_clicked" ||
+          event === "marketing_source_clicked";
         if (!isMarketingEvent || !isAcquisitionSource(source) || source === "invite") {
           return json({ error: "Unsupported event." }, 400);
         }


### PR DESCRIPTION
## Summary
- add a clear source-inspection action beside the room CTA on every marketing page
- record aggregate source-click events by allowlisted marketing slug
- preserve the existing privacy boundary: no user, room, referrer, URL, or content identifiers

## Why
The first fixed-baseline funnel read shows 13 architecture-guide views and no room CTA clicks. GitHub stars moved from 0 to 3, but source clicks were invisible. This distinguishes developer interest from room intent so the campaign can invest in the loop that actually responds.

## Validation
- `npm run typecheck`
- `npm run test --workspaces --if-present` (no workspace test scripts currently)
- `npm run build`
- `git diff --check`