### PR TITLE
Track allowlisted external referrals

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import {
   FILE_CHUNK_BYTES,
   isAcquisitionSource,
+  isExternalAcquisitionSource,
   MAX_FILE_BYTES,
   MAX_TRANSCRIPT_SYNC_MESSAGES,
   type CreateRoomRequest,
@@ -700,6 +701,13 @@ function LandingPage() {
     return () => {
       active = false;
     };
+  }, []);
+
+  useEffect(() => {
+    const source = new URLSearchParams(window.location.search).get("source");
+    if (isExternalAcquisitionSource(source)) {
+      recordGrowthEvent("external_referral_viewed", source);
+    }
   }, []);
 
   function updateDurationIndefinite(kind: DurationKind, checked: boolean) {

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -1,15 +1,16 @@
-import type { MarketingAcquisitionSource } from "@elm-chat/shared";
+import type { NonInviteAcquisitionSource } from "@elm-chat/shared";
 
 type ClientGrowthEvent =
   | "make_your_own_clicked"
   | "marketing_page_viewed"
   | "marketing_cta_clicked"
   | "marketing_source_clicked"
-  | "marketing_deploy_clicked";
+  | "marketing_deploy_clicked"
+  | "external_referral_viewed";
 
 export function recordGrowthEvent(
   event: ClientGrowthEvent,
-  source?: MarketingAcquisitionSource
+  source?: NonInviteAcquisitionSource
 ): void {
   const body = JSON.stringify({ event, source });
   if (navigator.sendBeacon) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,8 +16,7 @@ export const FILE_CHUNK_BYTES = 64 * 1024;
 
 export type RoomStatus = "open" | "expired" | "destroyed";
 
-export const ACQUISITION_SOURCES = [
-  "invite",
+export const MARKETING_ACQUISITION_SOURCES = [
   "self-destructing-chat",
   "send-a-password-securely",
   "one-time-secret-chat",
@@ -27,13 +26,33 @@ export const ACQUISITION_SOURCES = [
   "durable-objects-websocket-hibernation"
 ] as const;
 
+export const EXTERNAL_ACQUISITION_SOURCES = ["freshcode"] as const;
+
+export const ACQUISITION_SOURCES = [
+  "invite",
+  ...MARKETING_ACQUISITION_SOURCES,
+  ...EXTERNAL_ACQUISITION_SOURCES
+] as const;
+
 export type AcquisitionSource = (typeof ACQUISITION_SOURCES)[number];
-export type MarketingAcquisitionSource = Exclude<AcquisitionSource, "invite">;
+export type MarketingAcquisitionSource =
+  (typeof MARKETING_ACQUISITION_SOURCES)[number];
+export type ExternalAcquisitionSource = (typeof EXTERNAL_ACQUISITION_SOURCES)[number];
+export type NonInviteAcquisitionSource = Exclude<AcquisitionSource, "invite">;
 
 export function isAcquisitionSource(value: unknown): value is AcquisitionSource {
   return (
     typeof value === "string" &&
     (ACQUISITION_SOURCES as readonly string[]).includes(value)
+  );
+}
+
+export function isExternalAcquisitionSource(
+  value: unknown
+): value is ExternalAcquisitionSource {
+  return (
+    typeof value === "string" &&
+    (EXTERNAL_ACQUISITION_SOURCES as readonly string[]).includes(value)
   );
 }
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_DISAPPEAR_AFTER_READ_SECONDS,
   DEFAULT_INACTIVITY_TIMEOUT_MS,
   isAcquisitionSource,
+  isExternalAcquisitionSource,
   ROOM_ID_BYTES,
   type CreateRoomRequest,
   type CreateRoomResponse
@@ -23,6 +24,7 @@ type GrowthEvent =
   | "marketing_cta_clicked"
   | "marketing_source_clicked"
   | "marketing_deploy_clicked"
+  | "external_referral_viewed"
   | "room_created"
   | "invite_created";
 
@@ -307,6 +309,13 @@ function routeApi(request: Request, env: Env): Promise<Response> {
       .then(({ event, source }) => {
         if (event === "make_your_own_clicked") {
           recordGrowth(env, event);
+          return new Response(null, { status: 204 });
+        }
+        if (event === "external_referral_viewed") {
+          if (!isExternalAcquisitionSource(source)) {
+            return json({ error: "Unsupported event." }, 400);
+          }
+          recordGrowth(env, event, source);
           return new Response(null, { status: 204 });
         }
         const isMarketingEvent =


### PR DESCRIPTION
## What changed

- separates editorial page slugs from external acquisition sources
- allows the fixed `freshcode` campaign source and no arbitrary values
- records an aggregate `external_referral_viewed` event on tagged homepage visits
- attributes a room created from that same tagged URL to `freshcode`

## Privacy boundary

This does not record raw referrers, arbitrary URLs, query strings, cookies, user or room IDs, IP addresses, messages, files, or participant data. The Worker accepts only the compile-time `freshcode` source and rejects unknown sources.

## Verification

- `npm run typecheck`
- `npm run build`
- `git diff --check`

The production-path check will create exactly one documented synthetic `external_referral_viewed` row after merge and deployment.