### PR TITLE
Add public contributor discussion hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,16 @@ You don't have to write code to help:
 - **Bug reports** — file precise, reproducible issues.
 
 See [good first issues](docs/GOOD-FIRST-ISSUES.md) for scoped starting points.
+For design questions, self-hosting reports, and ideas that are not yet actionable bugs,
+use [GitHub Discussions](https://github.com/shawnbure/elm-chat/discussions). The
+[start-here discussion](https://github.com/shawnbure/elm-chat/discussions/42)
+collects the live demo, architecture, threat model, and current newcomer tasks.
 
 ## Ground rules
 
 1. **Privacy is the product.** If a change improves convenience but expands retention, logging, observability, or recoverable history, it will be challenged hard. Justify any new data that touches the server.
 2. **No new telemetry on room contents.** Aggregate, content-free counters on public surfaces (landing/invite pages) are fine; anything that could deanonymize participants or reconstruct a transcript is not.
-3. **Small, reviewable PRs.** One concern per pull request. Large refactors should start as an issue for discussion.
+3. **Small, reviewable PRs.** One concern per pull request. Large refactors should start in [Discussions](https://github.com/shawnbure/elm-chat/discussions) before becoming an issue or pull request.
 4. **Explain the security implications.** Every PR description should answer: does this change what the server can see, retain, or reconstruct?
 
 ## Development setup

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![Built with Cloudflare](https://workers.cloudflare.com/built-with-cloudflare.svg)](https://elm.chat/building-ephemeral-chat-cloudflare)
 ![Stars](https://img.shields.io/github/stars/shawnbure/elm-chat?style=social)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![GitHub Discussions](https://img.shields.io/github/discussions/shawnbure/elm-chat?label=discussions)](https://github.com/shawnbure/elm-chat/discussions)
 
-> **Instant chat. Private, secure, fast and disposable.** End-to-end encrypted rooms that self-destruct. No accounts and no server-side transcript.
+> **Instant chat. Account-free, encrypted, fast and disposable.** End-to-end encrypted rooms that self-destruct, with no persisted server-side transcript. This early-stage release has not had an independent security audit.
 
 ![elm.chat two-user demo — create a room, share a single-use invite, chat end-to-end encrypted, watch messages vanish, then destroy the room](docs/images/elm-chat-demo.gif)
 
@@ -15,6 +16,8 @@
 `elm.chat` is an open effort to build a messaging system for people who need privacy by default, operational simplicity, and as little server trust as possible.
 
 This repository is for builders, reviewers, security researchers, and contributors who want to help push the project toward a genuinely minimal-footprint private communication model.
+
+New here? Start with the public [try, review, or contribute guide](https://github.com/shawnbure/elm-chat/discussions/42), ask a question in [Discussions](https://github.com/shawnbure/elm-chat/discussions), or choose a scoped [good first issue](https://github.com/shawnbure/elm-chat/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 
 Try [elm.chat](https://elm.chat), read [why I built a messenger designed to disappear](https://elm.chat/why-i-built-elm-chat), learn what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guide to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare), or see how [WebSocket hibernation works without a chat database](https://elm.chat/durable-objects-websocket-hibernation).
 


### PR DESCRIPTION
## Summary

- link the new public Discussions space and start-here guide from the repository entry points
- route broad ideas and self-hosting questions to Discussions before they become issues
- replace the unqualified first-screen “secure” claim with accurate early-stage and audit language

## Verification

- `git diff --check`
- Discussions badge returns HTTP 200
- Discussions index and start-here thread return HTTP 200

## Security / privacy

Documentation-only. No runtime behavior, server visibility, retention, or analytics changes.