### PR TITLE
Convert Freshcode release visitors

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -675,6 +675,8 @@ function LandingPage() {
     "https://github.com/shawnbure/elm-chat/blob/main/docs/why-use-elm-chat.md";
   const articleUrl =
     "https://github.com/shawnbure/elm-chat/blob/main/docs/truly-private-messaging.md";
+  const sourceParam = new URLSearchParams(window.location.search).get("source");
+  const externalSource = isExternalAcquisitionSource(sourceParam) ? sourceParam : null;
   const [messageDuration, setMessageDuration] = useState<DurationDraft>({
     amount: "7",
     unit: "minutes",
@@ -704,11 +706,10 @@ function LandingPage() {
   }, []);
 
   useEffect(() => {
-    const source = new URLSearchParams(window.location.search).get("source");
-    if (isExternalAcquisitionSource(source)) {
-      recordGrowthEvent("external_referral_viewed", source);
+    if (externalSource) {
+      recordGrowthEvent("external_referral_viewed", externalSource);
     }
-  }, []);
+  }, [externalSource]);
 
   function updateDurationIndefinite(kind: DurationKind, checked: boolean) {
     if (kind === "message") {
@@ -749,6 +750,34 @@ function LandingPage() {
     <main className="landing-shell">
       <section className="hero">
         <div className="hero-copy">
+          {externalSource === "freshcode" ? (
+            <aside className="external-arrival" aria-label="elm.chat release details">
+              <span className="external-arrival-label">Found via Freshcode</span>
+              <strong>elm.chat v0.1.0 is open for inspection.</strong>
+              <p>
+                Try a short-lived room below, review the documented limits, or deploy your own
+                Cloudflare instance. This early release has not had an independent security audit.
+              </p>
+              <div className="external-arrival-actions">
+                <a
+                  href={`${GITHUB_URL}/releases/tag/v0.1.0`}
+                  onClick={() => recordGrowthEvent("external_source_clicked", externalSource)}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Inspect v0.1.0
+                </a>
+                <a
+                  href={`https://deploy.workers.cloudflare.com/?url=${GITHUB_URL}`}
+                  onClick={() => recordGrowthEvent("external_deploy_clicked", externalSource)}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Deploy your own
+                </a>
+              </div>
+            </aside>
+          ) : null}
           <div className="hero-links" aria-label="Learn about elm chat">
             <a className="hero-link" href={whyUseUrl} rel="noreferrer" target="_blank">
               Why use this?
@@ -758,7 +787,7 @@ function LandingPage() {
             </a>
           </div>
           <p className="eyebrow">elm chat</p>
-          <h1>Instant chat. Private, secure, fast and disposable.</h1>
+          <h1>Instant chat. Account-free, encrypted, fast and disposable.</h1>
           <p className="lede">
             Encrypted link-based chat with color identity, no usernames, and room rules you set before anyone joins.
           </p>

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -6,7 +6,9 @@ type ClientGrowthEvent =
   | "marketing_cta_clicked"
   | "marketing_source_clicked"
   | "marketing_deploy_clicked"
-  | "external_referral_viewed";
+  | "external_referral_viewed"
+  | "external_source_clicked"
+  | "external_deploy_clicked";
 
 export function recordGrowthEvent(
   event: ClientGrowthEvent,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -94,6 +94,53 @@ select {
   justify-content: flex-start;
 }
 
+.external-arrival {
+  margin: 0 0 18px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--accent), transparent 72%);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--accent), white 94%);
+}
+
+.external-arrival-label {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--accent-strong);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.external-arrival strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.external-arrival p {
+  margin: 6px 0 10px;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.external-arrival-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.external-arrival-actions a {
+  color: var(--accent-strong);
+  font-size: 0.84rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.external-arrival-actions a:hover {
+  text-decoration: underline;
+}
+
 .eyebrow {
   margin: 0 0 12px;
   text-transform: uppercase;

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -25,6 +25,8 @@ type GrowthEvent =
   | "marketing_source_clicked"
   | "marketing_deploy_clicked"
   | "external_referral_viewed"
+  | "external_source_clicked"
+  | "external_deploy_clicked"
   | "room_created"
   | "invite_created";
 
@@ -311,7 +313,11 @@ function routeApi(request: Request, env: Env): Promise<Response> {
           recordGrowth(env, event);
           return new Response(null, { status: 204 });
         }
-        if (event === "external_referral_viewed") {
+        const isExternalEvent =
+          event === "external_referral_viewed" ||
+          event === "external_source_clicked" ||
+          event === "external_deploy_clicked";
+        if (isExternalEvent) {
           if (!isExternalAcquisitionSource(source)) {
             return json({ error: "Unsupported event." }, 400);
           }


### PR DESCRIPTION
## Summary

- show a concise developer entry panel only for the fixed `?source=freshcode` campaign
- offer release inspection and one-click self-hosting alongside the existing room-creation path
- measure only aggregate allowlisted source/deploy actions
- replace the unqualified landing-page “secure” claim with accurate encrypted/account-free wording

Freshcode produced the first real tagged external visit at `2026-08-03 16:27:03 UTC`; this change improves message match for that exact audience.

## Verification

- `npm run typecheck`
- `npm run build`
- `git diff --check`
- local desktop and narrow-viewport rendered screenshots inspected

## Privacy / security

The new events contain only a compile-time allowlisted event name and the literal source `freshcode`. They do not contain a raw URL/referrer, cookie, IP, user ID, room ID, message, file, or participant data. The panel explicitly states that v0.1.0 has not had an independent security audit.