### PR TITLE
Improve contributor conversion path

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -909,11 +909,19 @@ function LandingPage() {
         <div className="hero-panel">
           <div className="signal-grid" />
           <div className="hero-panel-top">
-          <a className="github-cta" href={GITHUB_URL} rel="noreferrer" target="_blank">
+          <a
+            className="github-cta"
+            href={GITHUB_URL}
+            onClick={() =>
+              recordGrowthEvent("github_star_clicked", externalSource ?? undefined)
+            }
+            rel="noreferrer"
+            target="_blank"
+          >
             <GithubMark size={22} />
             <span className="github-cta-copy">
-              <strong>Star us on GitHub</strong>
-              <span>Open source. Audit the code, fork it, run your own.</span>
+              <strong>Star or inspect on GitHub</strong>
+              <span>Open source. Review every claim, fork it, or help build it.</span>
             </span>
             <span className="github-cta-stats" aria-label="GitHub stars and forks">
               {ghStats.stars !== null ? (
@@ -935,8 +943,16 @@ function LandingPage() {
             <a className="github-mini" href={`${GITHUB_URL}/fork`} rel="noreferrer" target="_blank">
               Fork me
             </a>
-            <a className="github-mini" href={`${GITHUB_URL}/blob/main/apps/web/src/App.tsx`} rel="noreferrer" target="_blank">
-              Read my code
+            <a
+              className="github-mini"
+              href={`${GITHUB_URL}/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22`}
+              onClick={() =>
+                recordGrowthEvent("good_first_issue_clicked", externalSource ?? undefined)
+              }
+              rel="noreferrer"
+              target="_blank"
+            >
+              Pick 1 of 8 starter issues
             </a>
           </div>
           </div>

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -8,7 +8,9 @@ type ClientGrowthEvent =
   | "marketing_deploy_clicked"
   | "external_referral_viewed"
   | "external_source_clicked"
-  | "external_deploy_clicked";
+  | "external_deploy_clicked"
+  | "github_star_clicked"
+  | "good_first_issue_clicked";
 
 export function recordGrowthEvent(
   event: ClientGrowthEvent,

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -27,6 +27,8 @@ type GrowthEvent =
   | "external_referral_viewed"
   | "external_source_clicked"
   | "external_deploy_clicked"
+  | "github_star_clicked"
+  | "good_first_issue_clicked"
   | "room_created"
   | "invite_created";
 
@@ -312,6 +314,14 @@ function routeApi(request: Request, env: Env): Promise<Response> {
       .then(({ event, source }) => {
         if (event === "make_your_own_clicked") {
           recordGrowth(env, event);
+          return new Response(null, { status: 204 });
+        }
+        if (event === "github_star_clicked" || event === "good_first_issue_clicked") {
+          recordGrowth(
+            env,
+            event,
+            isAcquisitionSource(source) && source !== "invite" ? source : "direct"
+          );
           return new Response(null, { status: 204 });
         }
         const isExternalEvent =


### PR DESCRIPTION
## What changed

- turns the homepage GitHub card into a clearer star-or-contribute path
- links directly to the eight scoped good first issue tasks
- records privacy-safe GitHub-interest and starter-issue click counters
- attributes tagged Freshcode arrivals without cookies or personal data

## Why

The Up For Grabs submission has passed its automated contributor-readiness check, while stars, forks, and issue participation remain flat. This gives that discovery loop an explicit next action and a measurable conversion event.

## Verification

- npm run typecheck
- npm run build
- git diff --check

Security posture is unchanged. elm.chat remains early-stage, has not had an independent security audit, exposes ordinary relay metadata, and does not yet implement message authentication.