### PR TITLE
Submit forgetting essay to IndexNow

### DIFF
--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -10,6 +10,7 @@ const urlList = [
   `https://${host}/journalist-source-communication`,
   `https://${host}/temporary-financial-handoff`,
   `https://${host}/press`,
+  `https://${host}/the-internet-needs-places-that-forget`,
   `https://${host}/why-i-built-elm-chat`,
   `https://${host}/building-ephemeral-chat-cloudflare`,
   `https://${host}/durable-objects-websocket-hibernation`


### PR DESCRIPTION
Adds the new public-interest essay to the reusable IndexNow URL list. The live endpoint accepted all 12 URLs with HTTP 200 before this PR was opened.