### PR TITLE
Preserve active room when invite guests create their own

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -530,8 +530,10 @@ function MakeYourOwnCallout({ compact = false }: { compact?: boolean }) {
         className="make-your-own-link"
         href="/?source=invite"
         onClick={recordMakeYourOwnClick}
+        rel={compact ? "noreferrer" : undefined}
+        target={compact ? "_blank" : undefined}
       >
-        Create your own &mdash; free, no signup.
+        {compact ? "Open your own in a new tab" : "Create your own"} &mdash; free, no signup.
       </a>
     </p>
   );


### PR DESCRIPTION
## Summary

- open the invite guest's in-room “make your own” CTA in a new tab
- keep the active encrypted room connected while the guest explores room creation
- retain the existing privacy-safe `make_your_own_clicked` event and `source=invite` attribution
- clarify in the compact CTA that the new room opens in another tab

## Why

The existing invite-loop prompt navigated away from the active conversation. That asks a participant to abandon the product experience at the moment of conversion. Preserving the room removes that friction without adding tracking or identifiers.

## Verification

- `npm run typecheck`
- `npm run build`
- local end-to-end browser check with a real room and redeemed one-time invite
- verified CTA `target=_blank`
- verified the guest room URL remained unchanged after click
- verified the landing page loaded separately and `/api/growth` returned 204