### PR TITLE
Publish RSS feed for elm.chat articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ New here? Start with the public [try, review, or contribute guide](https://githu
 
 Try [elm.chat](https://elm.chat), review its [public security status and limitations](https://elm.chat/security-and-limitations), open the [press and media kit](https://elm.chat/press), read why [the internet needs places that are allowed to forget](https://elm.chat/the-internet-needs-places-that-forget) or [why I built a messenger designed to disappear](https://elm.chat/why-i-built-elm-chat), learn what [self-destructing chat should actually mean](https://elm.chat/self-destructing-chat), follow the practical guides to [sending a password without leaving it in chat history](https://elm.chat/send-a-password-securely) and [sending a file without creating another attachment archive](https://elm.chat/send-a-file-securely), compare a [one-time secret with a disposable chat](https://elm.chat/one-time-secret-chat), create a [temporary private chat without signup](https://elm.chat/temporary-private-chat), choose a [communication channel for a journalist and source](https://elm.chat/journalist-source-communication), explore the [Cloudflare Durable Objects architecture](https://elm.chat/building-ephemeral-chat-cloudflare), or see how [WebSocket hibernation works without a chat database](https://elm.chat/durable-objects-websocket-hibernation).
 
+Subscribe to the [RSS feed](https://elm.chat/feed.xml) for new articles and technical notes.
+
 ## Run your own in one click
 
 elm.chat is Cloudflare-native, so you can fork and self-host a full private instance in about a minute — Cloudflare clones the repo into your account and provisions the Durable Objects for you:

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -10,6 +10,7 @@
       content="Create a disposable encrypted chat room with no account, single-use invites, and no server-side transcript."
     />
     <link rel="canonical" href="https://elm.chat/" />
+    <link rel="alternate" type="application/rss+xml" title="elm.chat articles and technical notes" href="https://elm.chat/feed.xml" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="elm.chat" />
     <meta property="og:title" content="elm.chat — One conversation. Then gone." />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "vite": "^6.3.2"
   },
   "scripts": {
-    "build": "vite build && node scripts/gen-sitemap.mjs && node scripts/prerender-marketing.mjs",
+    "build": "vite build && node scripts/gen-sitemap.mjs && node scripts/prerender-marketing.mjs && node scripts/gen-feed.mjs",
     "dev": "vite",
     "indexnow": "node scripts/submit-indexnow.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/apps/web/scripts/gen-feed.mjs
+++ b/apps/web/scripts/gen-feed.mjs
@@ -1,0 +1,91 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ORIGIN = process.env.SITE_ORIGIN ?? "https://elm.chat";
+const slugs = [
+  "security-and-limitations",
+  "send-a-file-securely",
+  "temporary-financial-handoff",
+  "the-internet-needs-places-that-forget",
+  "why-i-built-elm-chat",
+  "building-ephemeral-chat-cloudflare",
+  "durable-objects-websocket-hibernation",
+  "journalist-source-communication",
+  "temporary-private-chat",
+  "one-time-secret-chat",
+  "send-a-password-securely",
+  "self-destructing-chat"
+];
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function readPage(slug, position) {
+  const html = readFileSync(join("dist", slug, "index.html"), "utf8");
+  const structuredDataMatch = html.match(
+    /<script id="structured-data" type="application\/ld\+json">([\s\S]*?)<\/script>/
+  );
+  if (!structuredDataMatch) {
+    throw new Error(`Missing structured data for ${slug}`);
+  }
+
+  const data = JSON.parse(structuredDataMatch[1]);
+  const title = data.headline ?? data.name;
+  const description = data.description;
+  const published = data.datePublished;
+  if (!title || !description || !published) {
+    throw new Error(`Incomplete feed metadata for ${slug}`);
+  }
+
+  return {
+    description,
+    position,
+    published,
+    title,
+    url: `${ORIGIN}/${slug}`
+  };
+}
+
+const items = slugs
+  .map(readPage)
+  .sort(
+    (left, right) =>
+      Date.parse(right.published) - Date.parse(left.published) ||
+      left.position - right.position
+  );
+
+const itemXml = items
+  .map(
+    (item) => `    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(item.url)}</link>
+      <guid isPermaLink="true">${escapeXml(item.url)}</guid>
+      <description>${escapeXml(item.description)}</description>
+      <pubDate>${new Date(`${item.published}T00:00:00Z`).toUTCString()}</pubDate>
+    </item>`
+  )
+  .join("\n");
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>elm.chat — articles and technical notes</title>
+    <link>${ORIGIN}/</link>
+    <description>Writing about ephemeral encrypted messaging, deliberate data minimization, Cloudflare architecture, and the limits of disposable communication.</description>
+    <language>en-us</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <generator>elm.chat build</generator>
+    <atom:link href="${ORIGIN}/feed.xml" rel="self" type="application/rss+xml" />
+${itemXml}
+  </channel>
+</rss>
+`;
+
+writeFileSync("dist/feed.xml", xml);
+console.log(`feed.xml generated with ${items.length} entries`);

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -447,6 +447,7 @@ const pages = {
           <li><a href="/building-ephemeral-chat-cloudflare">Architecture walkthrough</a></li>
           <li><a href="/journalist-source-communication">Journalist and source channel guide</a></li>
           <li><a href="/temporary-financial-handoff">Financial data-minimization essay</a></li>
+          <li><a href="/feed.xml">RSS feed for articles and technical notes</a></li>
           <li><a href="https://github.com/shawnbure/elm-chat/releases/tag/v0.1.0">Current public release</a></li>
         </ul>
       </section>
@@ -758,6 +759,7 @@ for (const [slug, page] of Object.entries(pages)) {
         <a class="marketing-brand" href="/">elm.chat</a>
         <div>
           <a href="/press">Press kit</a>
+          <a href="/feed.xml">RSS</a>
           <a href="/security-and-limitations">Security</a>
           <a href="https://github.com/shawnbure/elm-chat">Source</a>
           <a href="https://github.com/shawnbure/elm-chat/blob/main/docs/threat-model.md">Threat model</a>

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -738,6 +738,7 @@ const pages: Record<MarketingSlug, MarketingPageContent> = {
             <li><a href="/journalist-source-communication">Journalist and source channel guide</a></li>
             <li><a href="/temporary-financial-handoff">Financial data-minimization essay</a></li>
             <li><a href="/the-internet-needs-places-that-forget">Public-interest essay on technology that forgets</a></li>
+            <li><a href="/feed.xml">RSS feed for articles and technical notes</a></li>
             <li><a href="https://github.com/shawnbure/elm-chat/releases/tag/v0.1.0" rel="noreferrer" target="_blank">Current public release</a></li>
           </ul>
         </section>
@@ -1237,6 +1238,7 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
         </a>
         <div>
           <a href="/press">Press kit</a>
+          <a href="/feed.xml">RSS</a>
           <a href="/security-and-limitations">Security</a>
           <a href={GITHUB_URL} rel="noreferrer" target="_blank">
             Source


### PR DESCRIPTION
## Summary

- generate a 12-entry RSS 2.0 feed from the authoritative structured metadata in each prerendered page
- advertise `/feed.xml` from the HTML head on the landing page and every article
- expose RSS in the marketing navigation, press kit, and README
- fail the build when a feed page is missing required title, description, or publication-date metadata

## Why

elm.chat already publishes technical and public-interest articles, but aggregators, newsletter editors, feed readers, and machine discovery systems had no subscription endpoint. This turns the existing article library into reusable organic distribution infrastructure.

## Verification

- `npm run typecheck`
- `npm run build`
- `xmllint --noout apps/web/dist/feed.xml`
- verified exactly 12 `<item>` entries
- verified RSS autodiscovery on the landing page and prerendered pages
- verified RSS navigation and press-kit links
- `git diff --check`