### PR TITLE
Prepare elm.chat v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to elm.chat are documented here.
+
+## [0.1.1] - 2026-08-03
+
+This release makes the early-stage project's operating boundaries easier to
+inspect and improves the path from an invited conversation to creating a new
+room.
+
+### Added
+
+- A public [security status and limitations](https://elm.chat/security-and-limitations)
+  page covering the current audit, authentication, replay, relay-metadata, and
+  endpoint-copy boundaries.
+- A public [independent-review request](https://github.com/shawnbure/elm-chat/issues/56)
+  for protocol, browser-client, relay, and lifecycle feedback. Suspected
+  vulnerabilities still belong in private GitHub security reports.
+- A [press and media kit](https://elm.chat/press), public-interest and technical
+  articles, practical temporary-handoff guides, and a 12-entry
+  [RSS feed](https://elm.chat/feed.xml).
+- Structured metadata, prerendered article pages, sitemap generation, and
+  IndexNow support for the public documentation and guides.
+
+### Changed
+
+- The invited-participant “make your own” action now opens a new tab, preserving
+  the active room instead of navigating away from the conversation.
+- Contributor and self-hosting routes are easier to find from the repository
+  and public documentation.
+
+### Security status
+
+elm.chat has not completed an independent security audit. Message
+authentication and replay/duplicate protection remain unfinished. The
+Cloudflare relay can observe ordinary connection metadata, and participants or
+compromised devices can retain message or file copies. This release is not an
+anonymity system, high-risk source channel, compliance product, or
+production-ready financial communications system.
+
+## [0.1.0] - 2026-07-28
+
+- First tagged public release.
+- Browser-side encryption for messages and files.
+- Single-use and revocable invitations.
+- Manual and timed room destruction.
+- Account-free rooms with no server-persisted transcript.
+- One Cloudflare Durable Object per live room and an AGPL-3.0 self-hosting path.
+
+[0.1.1]: https://github.com/shawnbure/elm-chat/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/shawnbure/elm-chat/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # elm.chat
 
+[Changelog](CHANGELOG.md) · [Latest release](https://github.com/shawnbure/elm-chat/releases/latest)
+
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
 [![Built with Cloudflare](https://workers.cloudflare.com/built-with-cloudflare.svg)](https://elm.chat/building-ephemeral-chat-cloudflare)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/durable-objects/room/package.json
+++ b/durable-objects/room/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/room-do",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "apps/web": {
       "name": "@elm-chat/web",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@elm-chat/crypto": "*",
         "@elm-chat/shared": "*",
@@ -34,7 +34,7 @@
     },
     "durable-objects/room": {
       "name": "@elm-chat/room-do",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@elm-chat/shared": "*"
       }
@@ -3611,18 +3611,18 @@
     },
     "packages/crypto": {
       "name": "@elm-chat/crypto",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@elm-chat/shared": "*"
       }
     },
     "packages/shared": {
       "name": "@elm-chat/shared",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "workers/api": {
       "name": "@elm-chat/api",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@elm-chat/room-do": "*",
         "@elm-chat/shared": "*"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/crypto",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

- bump all workspace package versions to 0.1.1
- add a public changelog for the 38 commits shipped since v0.1.0
- link the changelog and latest GitHub release from the README
- document the current audit, authentication, replay, relay-metadata, and endpoint-copy boundaries in the release record

## Verification

- `npm run typecheck`
- `npm run build`
- `git diff --check`

After merge, this commit will be tagged `v0.1.1` and published as a GitHub release.