### PR TITLE
Track DEV and Hashnode acquisition sources

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,7 +32,11 @@ export const MARKETING_ACQUISITION_SOURCES = [
   "durable-objects-websocket-hibernation"
 ] as const;
 
-export const EXTERNAL_ACQUISITION_SOURCES = ["freshcode"] as const;
+export const EXTERNAL_ACQUISITION_SOURCES = [
+  "dev-community",
+  "freshcode",
+  "hashnode"
+] as const;
 
 export const ACQUISITION_SOURCES = [
   "invite",


### PR DESCRIPTION
## Summary
- accept `dev-community` and `hashnode` as external acquisition sources
- preserve the existing Freshcode source
- make article-driven room creation attributable instead of falling back to direct

## Verification
- `npm run typecheck`
- `npm run build`