### PR TITLE
Track Reddit selfhosted acquisition

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,7 +35,8 @@ export const MARKETING_ACQUISITION_SOURCES = [
 export const EXTERNAL_ACQUISITION_SOURCES = [
   "dev-community",
   "freshcode",
-  "hashnode"
+  "hashnode",
+  "reddit-selfhosted"
 ] as const;
 
 export const ACQUISITION_SOURCES = [


### PR DESCRIPTION
Adds a dedicated `reddit-selfhosted` acquisition source before the project is shared in r/selfhosted's weekly New Project Megathread.

Verified with:
- `npm run typecheck`
- `npm run build`