### PR TITLE
Track r/CloudFlare acquisition

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "dev-community",
   "freshcode",
   "hashnode",
+  "reddit-cloudflare",
   "reddit-selfhosted"
 ] as const;
 


### PR DESCRIPTION
Adds a dedicated `reddit-cloudflare` acquisition source before sharing the Durable Objects architecture with r/CloudFlare.

Verified with:
- `npm run typecheck`
- `npm run build`