### PR TITLE
Track llms.txt acquisition

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,6 +38,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "freshcode",
   "github-readme",
   "hashnode",
+  "llms-txt",
   "reddit-cloudflare",
   "reddit-selfhosted"
 ] as const;


### PR DESCRIPTION
## Summary

- recognize the fixed `llms-txt` source already used by the new machine-readable project map
- preserve elm.chat's aggregate-only acquisition measurement: no room, invite, participant, message, cookie, or user identifier is added

## Verification

- `npm run typecheck`
- `npm run build`
- `git diff --check`
