### PR TITLE
Make the homepage title descriptive

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -65,7 +65,7 @@
         ]
       }
     </script>
-    <title>elm chat</title>
+    <title>elm.chat — Disposable Encrypted Chat, No Account</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- replace the vague `elm chat` homepage title with a concise product description
- keep the more emotive Open Graph and social-card copy unchanged

The structured-data audit found that elm.chat already renders valid `WebSite`, `WebApplication`, `Article`, and `TechArticle` JSON-LD. The app does not yet have a genuine review or aggregate rating, so this change does not manufacture the rating Google requires for software-app rich-result eligibility.

## Verification

- `npm run typecheck`
- `npm run build`
- Worker dry-run
- `git diff --check`
- parsed all 14 rendered JSON-LD blocks
- verified all 14 rendered titles and canonical URLs exist and titles are unique
