### PR TITLE
Track README self-host intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Changelog](CHANGELOG.md) · [Latest release](https://github.com/shawnbure/elm-chat/releases/latest)
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://elm.chat/deploy/cloudflare?source=github-readme)
 [![Built with Cloudflare](https://workers.cloudflare.com/built-with-cloudflare.svg)](https://elm.chat/building-ephemeral-chat-cloudflare)
 [![Stars](https://img.shields.io/github/stars/shawnbure/elm-chat?style=social)](https://github.com/shawnbure/elm-chat/stargazers)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -42,7 +42,7 @@ Subscribe to the [RSS feed](https://elm.chat/feed.xml) for new articles and tech
 
 elm.chat is Cloudflare-native, so you can fork and self-host a full private instance in about a minute — Cloudflare clones the repo into your account and provisions the Durable Objects for you:
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://elm.chat/deploy/cloudflare?source=github-readme)
 
 Prefer to do it by hand? See [Deploy to Cloudflare](#deploy-to-cloudflare) below. Want to contribute instead of just run it? Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the [good first issues](docs/GOOD-FIRST-ISSUES.md).
 
@@ -171,7 +171,7 @@ No paid add-ons are required. SQLite-backed Durable Objects (what this project u
 
 ### Option A — one click
 
-1. Click **[Deploy to Cloudflare](https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat)**.
+1. Click **[Deploy to Cloudflare](https://elm.chat/deploy/cloudflare?source=github-readme)**.
 2. Authorize Cloudflare to create a fork in your GitHub account and connect it to Workers Builds.
 3. Set the build settings (see below). The build step compiles the React app into `apps/web/dist`, which the Worker serves.
 4. Deploy. Cloudflare provisions the Worker and the Durable Object namespace for you.

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -257,6 +257,8 @@ async function handleRevokeInvite(request: Request, roomId: string, env: Env): P
 }
 
 const GITHUB_REPO = "shawnbure/elm-chat";
+const CLOUDFLARE_DEPLOY_URL =
+  "https://deploy.workers.cloudflare.com/?url=https://github.com/shawnbure/elm-chat";
 const GITHUB_STATS_TTL_MS = 60 * 60 * 1000;
 const MARKETING_PATHS = new Set([
   "/self-destructing-chat",
@@ -308,6 +310,26 @@ async function handleGithubStats(): Promise<Response> {
     repo: GITHUB_REPO,
     stars: githubStatsCache.stars,
     forks: githubStatsCache.forks
+  });
+}
+
+function handleCloudflareDeploy(request: Request, env: Env): Response {
+  const source = new URL(request.url).searchParams.get("source");
+  if (request.method === "GET") {
+    recordGrowth(
+      env,
+      "external_deploy_clicked",
+      isAcquisitionSource(source) && source !== "invite" ? source : "direct"
+    );
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: CLOUDFLARE_DEPLOY_URL,
+      "cache-control": "no-store",
+      "referrer-policy": "no-referrer"
+    }
   });
 }
 
@@ -412,6 +434,13 @@ export default {
       } catch {
         return withSecurityHeaders(json({ error: "Internal error." }, 500));
       }
+    }
+
+    if (
+      url.pathname === "/deploy/cloudflare" &&
+      (request.method === "GET" || request.method === "HEAD")
+    ) {
+      return withSecurityHeaders(handleCloudflareDeploy(request, env));
     }
 
     // Every route runs through the Worker (run_worker_first) so security


### PR DESCRIPTION
## What changed

- route README deploy links through an elm.chat first-party redirect
- write only the fixed acquisition source to the existing aggregate Analytics Engine dataset
- preserve the direct Cloudflare one-click deployment destination
- ignore HEAD requests so basic link checks do not count as deploy intent

## Privacy and measurement boundary

This adds no cookie, user, room, invite, message, or participant identifier. A GET is only a deploy-intent signal and may still include automated fetches; it does not prove a completed fork or deployment. Completed self-host adoption remains a downstream fork/deploy outcome.

## Verification

- `npm run typecheck`
- `npm run build`
- `git diff --check`
- local Worker HEAD/GET requests return `302` to the exact Cloudflare deploy URL with `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, and the existing security headers