### PR TITLE
Reduce invite sharing friction

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -72,6 +72,7 @@ type IncomingFile = {
 };
 
 type ActionFeedback = "idle" | "success";
+type InviteFeedback = "idle" | "copied" | "shared";
 type DurationUnit = "minutes" | "hours" | "days";
 type DurationDraft = {
   amount: string;
@@ -1011,7 +1012,7 @@ function RoomPage({ roomId }: { roomId: string }) {
   const [notFound, setNotFound] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState<ActionFeedback>("idle");
   const [destroyFeedback, setDestroyFeedback] = useState<ActionFeedback>("idle");
-  const [inviteFeedback, setInviteFeedback] = useState<ActionFeedback>("idle");
+  const [inviteFeedback, setInviteFeedback] = useState<InviteFeedback>("idle");
   const [destroying, setDestroying] = useState(false);
   const [inviteAccess, setInviteAccess] = useState<"checking" | "granted" | "invalid">(
     isInviteGuest ? "checking" : "granted"
@@ -1590,7 +1591,7 @@ function RoomPage({ roomId }: { roomId: string }) {
   }, [copyFeedback]);
 
   useEffect(() => {
-    if (inviteFeedback !== "success") {
+    if (inviteFeedback === "idle") {
       return;
     }
     const timeout = window.setTimeout(() => setInviteFeedback("idle"), 1600);
@@ -1754,8 +1755,29 @@ function RoomPage({ roomId }: { roomId: string }) {
       const invite = await createInvite(roomId, creatorToken);
       setInvites((current) => [invite, ...current]);
       const inviteUrl = buildInviteUrl(roomId, invite.token, roomSecret);
+      if (typeof navigator.share === "function") {
+        try {
+          await navigator.share({
+            title: "elm.chat invite",
+            text: "Join my disposable elm.chat room. This single-use link expires.",
+            url: inviteUrl
+          });
+          recordGrowthEvent("invite_share_handoff");
+          setInviteFeedback("shared");
+          setRoomNotice("Invite handed to your selected app. The link can only be used once.");
+          setError(null);
+          return;
+        } catch (cause) {
+          if (cause instanceof DOMException && cause.name === "AbortError") {
+            setInviteFeedback("idle");
+            setRoomNotice("Invite created. Choose Share or Copy below when you are ready.");
+            setError(null);
+            return;
+          }
+        }
+      }
       if (await copyText(inviteUrl)) {
-        setInviteFeedback("success");
+        setInviteFeedback("copied");
         setRoomNotice("Invite copied. Send it to one person—the link can only be used once.");
         setError(null);
         return;
@@ -1770,12 +1792,33 @@ function RoomPage({ roomId }: { roomId: string }) {
 
   async function handleCopyInvite(token: string) {
     if (await copyText(buildInviteUrl(roomId, token, roomSecret))) {
-      setInviteFeedback("success");
+      setInviteFeedback("copied");
       setRoomNotice("Invite copied. Send it to one person—the link can only be used once.");
       setError(null);
       return;
     }
     setError("Clipboard access is blocked in this browser context. Copy the invite URL manually.");
+  }
+
+  async function handleNativeShareInvite(token: string) {
+    if (typeof navigator.share !== "function") {
+      return;
+    }
+    try {
+      await navigator.share({
+        title: "elm.chat invite",
+        text: "Join my disposable elm.chat room. This single-use link expires.",
+        url: buildInviteUrl(roomId, token, roomSecret)
+      });
+      recordGrowthEvent("invite_share_handoff");
+      setInviteFeedback("shared");
+      setRoomNotice("Invite handed to your selected app. The link can only be used once.");
+      setError(null);
+    } catch (cause) {
+      if (!(cause instanceof DOMException && cause.name === "AbortError")) {
+        setError("This browser could not open its share menu. Copy the invite instead.");
+      }
+    }
   }
 
   async function handleRevokeInvite(token: string) {
@@ -1887,10 +1930,16 @@ function RoomPage({ roomId }: { roomId: string }) {
           <div className="room-actions">
             {isCreator ? (
               <button
-                className={`secondary-button ${inviteFeedback === "success" ? "button-success" : ""}`}
+                className={`secondary-button ${inviteFeedback !== "idle" ? "button-success" : ""}`}
                 onClick={handleShareInvite}
               >
-                {inviteFeedback === "success" ? "Invite copied—send it" : "Invite one person"}
+                {inviteFeedback === "shared"
+                  ? "Invite shared"
+                  : inviteFeedback === "copied"
+                    ? "Invite copied—send it"
+                    : typeof navigator.share === "function"
+                      ? "Send invite"
+                      : "Invite one person"}
               </button>
             ) : (
               <button
@@ -1962,9 +2011,20 @@ function RoomPage({ roomId }: { roomId: string }) {
               </span>
               <div className="invite-actions">
                 {!invite.revokedAt && !invite.consumedAt ? (
-                  <button className="secondary-button invite-copy" onClick={() => handleCopyInvite(invite.token)} type="button">
-                    Copy
-                  </button>
+                  <>
+                    {typeof navigator.share === "function" ? (
+                      <button
+                        className="secondary-button invite-copy"
+                        onClick={() => handleNativeShareInvite(invite.token)}
+                        type="button"
+                      >
+                        Share
+                      </button>
+                    ) : null}
+                    <button className="secondary-button invite-copy" onClick={() => handleCopyInvite(invite.token)} type="button">
+                      Copy
+                    </button>
+                  </>
                 ) : null}
                 {!invite.revokedAt ? (
                   <button className="secondary-button invite-revoke" onClick={() => handleRevokeInvite(invite.token)} type="button">

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -2,6 +2,7 @@ import type { NonInviteAcquisitionSource } from "@elm-chat/shared";
 
 type ClientGrowthEvent =
   | "make_your_own_clicked"
+  | "invite_share_handoff"
   | "marketing_page_viewed"
   | "marketing_cta_clicked"
   | "marketing_source_clicked"

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -20,6 +20,7 @@ type Env = {
 
 type GrowthEvent =
   | "make_your_own_clicked"
+  | "invite_share_handoff"
   | "marketing_page_viewed"
   | "marketing_cta_clicked"
   | "marketing_source_clicked"
@@ -339,7 +340,7 @@ function routeApi(request: Request, env: Env): Promise<Response> {
   if (request.method === "POST" && url.pathname === "/api/growth") {
     return safeJson<{ event?: string; source?: string }>(request)
       .then(({ event, source }) => {
-        if (event === "make_your_own_clicked") {
+        if (event === "make_your_own_clicked" || event === "invite_share_handoff") {
           recordGrowth(env, event);
           return new Response(null, { status: 204 });
         }


### PR DESCRIPTION
## What changed

- prefer the browser/device native share sheet when a room creator makes an invite
- keep Copy as a visible fallback for every unused invite
- distinguish copied versus native-share feedback in the room UI
- record one aggregate `invite_share_handoff` event only after the selected share target accepts the invite data

## Why

The clean post-launch funnel has eight direct room creations and two invite creations, but no invite redemptions. The current copy-only handoff leaves a gap between creating an invite and actually moving it into the recipient's communication app.

## Privacy and measurement boundary

The new counter contains only the fixed event name and value `1`. It includes no room ID, invite token, participant, message, source, cookie, or device identifier. A share handoff is not counted as delivery, invite redemption, a new participant, or traction; `invite_redeemed` remains the downstream proof.

## Verification

- `npm run typecheck`
- `npm run build`
- `npx wrangler deploy --dry-run --config workers/api/wrangler.jsonc`
- local `/api/growth` validation: `invite_share_handoff` → 204; unsupported `invite_share_delivered` → 400
- `git diff --check`
