### PR TITLE
Track Zearches referral traffic

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,6 @@ import {
 import {
   FILE_CHUNK_BYTES,
   isAcquisitionSource,
-  isExternalAcquisitionSource,
   MAX_FILE_BYTES,
   MAX_TRANSCRIPT_SYNC_MESSAGES,
   type CreateRoomRequest,
@@ -27,7 +26,7 @@ import {
   type ServerEvent,
 } from "@elm-chat/shared";
 import { startTransition, useEffect, useRef, useState, type CSSProperties } from "react";
-import { recordGrowthEvent } from "./growth";
+import { recordGrowthEvent, resolveExternalAcquisitionSource } from "./growth";
 import { MarketingPage, type MarketingSlug } from "./MarketingPage";
 
 type View = "landing" | "marketing" | "room";
@@ -685,7 +684,7 @@ function LandingPage() {
   const articleUrl =
     "https://github.com/shawnbure/elm-chat/blob/main/docs/truly-private-messaging.md";
   const sourceParam = new URLSearchParams(window.location.search).get("source");
-  const externalSource = isExternalAcquisitionSource(sourceParam) ? sourceParam : null;
+  const externalSource = resolveExternalAcquisitionSource(sourceParam, document.referrer);
   const [messageDuration, setMessageDuration] = useState<DurationDraft>({
     amount: "7",
     unit: "minutes",

--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -1,4 +1,32 @@
-import type { NonInviteAcquisitionSource } from "@elm-chat/shared";
+import {
+  isExternalAcquisitionSource,
+  type ExternalAcquisitionSource,
+  type NonInviteAcquisitionSource
+} from "@elm-chat/shared";
+
+const EXTERNAL_REFERRER_SOURCES: Readonly<Record<string, ExternalAcquisitionSource>> = {
+  "www.zearches.com": "zearches",
+  "zearches.com": "zearches"
+};
+
+export function resolveExternalAcquisitionSource(
+  sourceParam: string | null,
+  referrer: string
+): ExternalAcquisitionSource | null {
+  if (isExternalAcquisitionSource(sourceParam)) {
+    return sourceParam;
+  }
+
+  if (!referrer) {
+    return null;
+  }
+
+  try {
+    return EXTERNAL_REFERRER_SOURCES[new URL(referrer).hostname.toLowerCase()] ?? null;
+  } catch {
+    return null;
+  }
+}
 
 type ClientGrowthEvent =
   | "make_your_own_clicked"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,7 +40,8 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "hashnode",
   "llms-txt",
   "reddit-cloudflare",
-  "reddit-selfhosted"
+  "reddit-selfhosted",
+  "zearches"
 ] as const;
 
 export const ACQUISITION_SOURCES = [


### PR DESCRIPTION
## Summary

- Recognize the fixed Zearches hostname as an external acquisition source.
- Preserve explicit `?source=` attribution as the higher-priority signal.
- Record only the existing aggregate referral and downstream funnel events.

## Privacy boundary

This maps only `zearches.com` and `www.zearches.com` to the fixed label
`zearches`. It stores no raw referrer, URL path, room, invite, participant,
message, cookie, or user identifier.

## Verification

- `npm run typecheck`
- `npm run build`
- `npm exec -- wrangler deploy --dry-run --config workers/api/wrangler.jsonc`
- `git diff --check`
