### PR TITLE
Track Free Startup Listing referrals

### DIFF
--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -5,6 +5,8 @@ import {
 } from "@elm-chat/shared";
 
 const EXTERNAL_REFERRER_SOURCES: Readonly<Record<string, ExternalAcquisitionSource>> = {
+  "freestartuplisting.org": "free-startup-listing",
+  "www.freestartuplisting.org": "free-startup-listing",
   "www.zearches.com": "zearches",
   "zearches.com": "zearches"
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "awesome-cloudflare",
   "dev-community",
   "freshcode",
+  "free-startup-listing",
   "github-readme",
   "hashnode",
   "llms-txt",


### PR DESCRIPTION
## Summary

- Add `free-startup-listing` to the closed external acquisition-source list.
- Map only the directory's apex and `www` hostnames to that fixed label.
- Keep explicit allowlisted `?source=` attribution higher priority.

## Privacy boundary

The existing growth endpoint receives only the fixed source label. It stores no
raw referrer, URL path, room, invite, participant, message, cookie, device, or
user identifier.

## Verification

- `npm run typecheck`
- `npm run build`
- `npm exec -- wrangler deploy --dry-run --config workers/api/wrangler.jsonc`
- `git diff --check`
