### PR TITLE
Clarify the guest invite loop CTA

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -525,7 +525,9 @@ function recordMakeYourOwnClick() {
 function MakeYourOwnCallout({ compact = false }: { compact?: boolean }) {
   return (
     <p className={`make-your-own ${compact ? "make-your-own-compact" : ""}`}>
-      {compact ? "Want a disposable room of your own? " : "This secure room was made with elm.chat. "}
+      {compact
+        ? "Try the invite loop yourself: "
+        : "This disposable room was made with elm.chat. "}
       <a
         className="make-your-own-link"
         href="/?source=invite"
@@ -533,7 +535,7 @@ function MakeYourOwnCallout({ compact = false }: { compact?: boolean }) {
         rel={compact ? "noreferrer" : undefined}
         target={compact ? "_blank" : undefined}
       >
-        {compact ? "Open your own in a new tab" : "Create your own"} &mdash; free, no signup.
+        Start your own room and invite one person &mdash; free, no signup.
       </a>
     </p>
   );


### PR DESCRIPTION
## What changed

- Reframes the invite-recipient callout around trying the invite loop
- Gives one explicit next action: start a room and invite one person
- Keeps the existing privacy-safe `make_your_own_clicked` measurement and `invite` attribution

## Why

The clean production stream recorded its first `invite_redeemed` event at 2026-08-04 18:08:40 UTC, after two direct room creations and one invite creation. No documented synthetic production action occurred in that window. The next loop step is an invite recipient creating a room of their own.

## Validation

- `npm run typecheck`
- `npm run build` (includes Worker dry-run)
- `npm exec wrangler deploy -- --dry-run --config workers/api/wrangler.jsonc`
- `git diff --check`
- verified both new strings in the production bundle

No encryption, invite, room, retention, analytics payload, or security behavior changes.