### PR TITLE
Measure LinuxLinks referrals

### DIFF
--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -7,6 +7,8 @@ import {
 const EXTERNAL_REFERRER_SOURCES: Readonly<Record<string, ExternalAcquisitionSource>> = {
   "freestartuplisting.org": "free-startup-listing",
   "www.freestartuplisting.org": "free-startup-listing",
+  "linuxlinks.com": "linuxlinks",
+  "www.linuxlinks.com": "linuxlinks",
   "www.zearches.com": "zearches",
   "zearches.com": "zearches"
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "github-readme",
   "hashnode",
   "llms-txt",
+  "linuxlinks",
   "reddit-cloudflare",
   "reddit-selfhosted",
   "zearches"


### PR DESCRIPTION
## What changed

- add `linuxlinks` to the bounded external acquisition-source allowlist
- map only `linuxlinks.com` and `www.linuxlinks.com` referrer hostnames to that label

## Why

A LinuxLinks v0.1.1 release note was sent through the publication current first-party press-release route. If the outlet later links to elm.chat without an explicit campaign parameter, the existing privacy-safe funnel can attribute the visit and downstream room/invite actions.

## Privacy impact

The change stores only the fixed `linuxlinks` label. It does not store a raw referrer, URL path, query string, room, invite, participant, message, cookie, device, or user identifier. An explicit allowlisted `?source=` value remains higher priority.

## Checks

- `pnpm typecheck`
- `npm run build`
- `git diff --check`