### PR TITLE
Track High Scalability referrals

### DIFF
--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -7,6 +7,8 @@ import {
 const EXTERNAL_REFERRER_SOURCES: Readonly<Record<string, ExternalAcquisitionSource>> = {
   "freestartuplisting.org": "free-startup-listing",
   "www.freestartuplisting.org": "free-startup-listing",
+  "highscalability.com": "high-scalability",
+  "www.highscalability.com": "high-scalability",
   "linuxlinks.com": "linuxlinks",
   "www.linuxlinks.com": "linuxlinks",
   "www.zearches.com": "zearches",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "free-startup-listing",
   "github-readme",
   "hashnode",
+  "high-scalability",
   "llms-txt",
   "linuxlinks",
   "reddit-cloudflare",


### PR DESCRIPTION
## Summary
- allow the fixed `high-scalability` acquisition label
- map only `highscalability.com` and `www.highscalability.com` referrers
- retain no raw referrer URL, path, query string, room, invite, participant, message, cookie, device, or user identifier

## Verification
- npm run typecheck
- npm run build
- git diff --check