### PR TITLE
Track SRE Weekly referrals

### DIFF
--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -11,6 +11,8 @@ const EXTERNAL_REFERRER_SOURCES: Readonly<Record<string, ExternalAcquisitionSour
   "www.highscalability.com": "high-scalability",
   "linuxlinks.com": "linuxlinks",
   "www.linuxlinks.com": "linuxlinks",
+  "sreweekly.com": "sre-weekly",
+  "www.sreweekly.com": "sre-weekly",
   "www.zearches.com": "zearches",
   "zearches.com": "zearches"
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,6 +45,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "linuxlinks",
   "reddit-cloudflare",
   "reddit-selfhosted",
+  "sre-weekly",
   "zearches"
 ] as const;
 


### PR DESCRIPTION
## Summary
- allow the fixed `sre-weekly` acquisition label
- map only `sreweekly.com` and `www.sreweekly.com` referrers
- retain no raw referrer URL, path, query string, room, invite, participant, message, cookie, device, or user identifier

## Verification
- npm run typecheck
- npm run build
- git diff --check