### PR TITLE
Track GitHub discussion referrals

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,6 +38,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "dev-community",
   "freshcode",
   "free-startup-listing",
+  "github-discussion",
   "github-readme",
   "hashnode",
   "high-scalability",


### PR DESCRIPTION
## Summary
- allow a fixed `github-discussion` acquisition label for measured links from repository discussions
- retain no discussion identifier, raw referrer URL, path, query string, room, invite, participant, message, cookie, device, or user identifier

## Verification
- npm run typecheck
- npm run build
- git diff --check