### PR TITLE
Track DevOps'ish referrals

### DIFF
--- a/apps/web/src/growth.ts
+++ b/apps/web/src/growth.ts
@@ -5,6 +5,8 @@ import {
 } from "@elm-chat/shared";
 
 const EXTERNAL_REFERRER_SOURCES: Readonly<Record<string, ExternalAcquisitionSource>> = {
+  "devopsish.com": "devopsish",
+  "www.devopsish.com": "devopsish",
   "freestartuplisting.org": "free-startup-listing",
   "www.freestartuplisting.org": "free-startup-listing",
   "highscalability.com": "high-scalability",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export const MARKETING_ACQUISITION_SOURCES = [
 export const EXTERNAL_ACQUISITION_SOURCES = [
   "awesome-cloudflare",
   "dev-community",
+  "devopsish",
   "freshcode",
   "free-startup-listing",
   "github-discussion",


### PR DESCRIPTION
## Summary
- add a fixed `devopsish` acquisition source
- map only `devopsish.com` and `www.devopsish.com` referrers
- preserve aggregate-only measurement with no raw referrer, path, query, room, invite, participant, message, cookie, device, or user identifier

## Verification
- `npm run typecheck`
- `npm run build`
- `git diff --check`