### PR TITLE
Track external referrals to article pages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -656,7 +656,9 @@ export function App() {
     return <RoomPage roomId={route.roomId} />;
   }
   if (route.view === "marketing" && route.marketingSlug) {
-    return <MarketingPage slug={route.marketingSlug} />;
+    const sourceParam = new URLSearchParams(window.location.search).get("source");
+    const externalSource = resolveExternalAcquisitionSource(sourceParam, document.referrer);
+    return <MarketingPage externalSource={externalSource} slug={route.marketingSlug} />;
   }
   return <LandingPage />;
 }

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -1,4 +1,7 @@
-import type { MarketingAcquisitionSource } from "@elm-chat/shared";
+import type {
+  ExternalAcquisitionSource,
+  MarketingAcquisitionSource
+} from "@elm-chat/shared";
 import { useEffect, type ReactNode } from "react";
 import { recordGrowthEvent } from "./growth";
 
@@ -1428,7 +1431,13 @@ function Limitations() {
   );
 }
 
-export function MarketingPage({ slug }: { slug: MarketingSlug }) {
+export function MarketingPage({
+  externalSource,
+  slug
+}: {
+  externalSource?: ExternalAcquisitionSource | null;
+  slug: MarketingSlug;
+}) {
   const page = pages[slug];
   const roomHref = `/?source=${slug}`;
 
@@ -1438,6 +1447,9 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
     const previousDescription = description?.content ?? "";
 
     recordGrowthEvent("marketing_page_viewed", slug);
+    if (externalSource) {
+      recordGrowthEvent("external_referral_viewed", externalSource);
+    }
     document.title = `${page.title} | elm.chat`;
     if (description) {
       description.content = page.description;
@@ -1449,7 +1461,7 @@ export function MarketingPage({ slug }: { slug: MarketingSlug }) {
         description.content = previousDescription;
       }
     };
-  }, [page, slug]);
+  }, [externalSource, page, slug]);
 
   return (
     <main className="marketing-shell">


### PR DESCRIPTION
## Summary
- resolve fixed external acquisition sources on marketing/article routes
- retain the existing page-level event and add one aggregate external-referral event
- preserve the privacy boundary: no raw referrer, URL path, query, room, invite, participant, message, cookie, device, or user identifier is stored

## Why
Editorial newsletters often deep-link to an article instead of the homepage. Those visits previously lost their fixed channel attribution.

## Verification
- `npm run typecheck`
- `npm run build`
- `git diff --check`