### PR TITLE
Prepare v0.1.2 maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to elm.chat are documented here.
 
+## [0.1.2] - 2026-08-05
+
+This maintenance release makes the public Cloudflare self-host path work from
+the repository root and reduces friction in the invite handoff.
+
+### Added
+
+- A root `wrangler.jsonc`, root build and deploy commands, and an automated
+  drift check so Cloudflare's deploy flow can detect the npm-workspaces project.
+- Privacy-safe aggregate counters for successful invite-share handoffs and
+  fixed-source discovery paths. Independent deployments omit elm.chat's
+  optional growth-measurement binding.
+- A provider-neutral engineering article and reproducible test matrix for
+  treating deletion as a distributed-systems contract.
+
+### Changed
+
+- The native share sheet is now used when available, with clipboard fallback
+  and clearer completion feedback for copied invitation links.
+- The client handles already-closed WebSockets more defensively during room
+  teardown and refresh flows.
+- Repository self-hosting actions now pass through one fixed, aggregate counter
+  before redirecting to the unchanged official Cloudflare deployment flow.
+
+### Security status
+
+elm.chat has not completed an independent security audit. Message
+authentication and replay/duplicate protection remain unfinished. The
+Cloudflare relay can observe ordinary connection metadata, and participants or
+compromised devices can retain message or file copies. This release is not an
+anonymity system, high-risk source channel, compliance product, or
+production-ready financial communications system.
+
 ## [0.1.1] - 2026-08-03
 
 This release makes the early-stage project's operating boundaries easier to
@@ -47,5 +80,6 @@ production-ready financial communications system.
 - Account-free rooms with no server-persisted transcript.
 - One Cloudflare Durable Object per live room and an AGPL-3.0 self-hosting path.
 
+[0.1.2]: https://github.com/shawnbure/elm-chat/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/shawnbure/elm-chat/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/shawnbure/elm-chat/releases/tag/v0.1.0

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/durable-objects/room/package.json
+++ b/durable-objects/room/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/room-do",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     },
     "apps/web": {
       "name": "@elm-chat/web",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@elm-chat/crypto": "*",
         "@elm-chat/shared": "*",
@@ -35,7 +35,7 @@
     },
     "durable-objects/room": {
       "name": "@elm-chat/room-do",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@elm-chat/shared": "*"
       }
@@ -3612,18 +3612,18 @@
     },
     "packages/crypto": {
       "name": "@elm-chat/crypto",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@elm-chat/shared": "*"
       }
     },
     "packages/shared": {
       "name": "@elm-chat/shared",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     "workers/api": {
       "name": "@elm-chat/api",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@elm-chat/room-do": "*",
         "@elm-chat/shared": "*"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/crypto",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/shared",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-chat/api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

- bump the private workspace packages to 0.1.2
- document the repaired root-level Cloudflare deploy contract
- document the invite-share and closed-WebSocket improvements
- carry the current security and intended-use boundaries into the release notes

## Verification

- `npm run typecheck`
- `npm run build`
- `npm run deploy -- --dry-run`
- `git diff --check`

## Release intent

This is a maintenance release centered on a concrete self-hosting fix: Cloudflare can now detect the npm-workspaces project from the repository root. It does not claim an independent audit, completed message authentication/replay protection, or user adoption.