### PR TITLE
Add a Cloudflare monorepo deploy-button debugging guide

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -17,6 +17,7 @@ elm.chat is an early-stage experiment in minimizing the transcript a chat servic
 - [Architecture](https://github.com/shawnbure/elm-chat/blob/main/docs/architecture.md): Understand the React client, Cloudflare Worker, Durable Objects, WebSockets, client-side cryptography, and room lifecycle.
 - [Protocol](https://github.com/shawnbure/elm-chat/blob/main/docs/protocol.md): Review the wire protocol and current cryptographic design.
 - [Building ephemeral chat with Cloudflare](https://elm.chat/building-ephemeral-chat-cloudflare): Read the implementation walkthrough and its engineering tradeoffs.
+- [Fix Deploy to Cloudflare in a monorepo](https://elm.chat/cloudflare-deploy-button-monorepo): Diagnose nested Wrangler configuration, expose a root deployment contract, prevent config drift, and test the public setup path.
 - [Deletion as a distributed-systems contract](https://elm.chat/deletion-distributed-systems-contract): Model state inventories, tombstones, recovery, resurrection failures, and verifiable deletion claims.
 - [Durable Objects WebSocket hibernation](https://elm.chat/durable-objects-websocket-hibernation): See how the relay handles sleeping connections without a chat-message database.
 - [Contributing](https://github.com/shawnbure/elm-chat/blob/main/CONTRIBUTING.md): Find development standards and ways to help.

--- a/apps/web/scripts/gen-feed.mjs
+++ b/apps/web/scripts/gen-feed.mjs
@@ -11,6 +11,7 @@ const slugs = [
   "deletion-distributed-systems-contract",
   "building-ephemeral-chat-cloudflare",
   "durable-objects-websocket-hibernation",
+  "cloudflare-deploy-button-monorepo",
   "journalist-source-communication",
   "temporary-private-chat",
   "one-time-secret-chat",

--- a/apps/web/scripts/gen-sitemap.mjs
+++ b/apps/web/scripts/gen-sitemap.mjs
@@ -23,7 +23,8 @@ const urls = [
   { path: "/why-i-built-elm-chat", changefreq: "monthly", priority: "0.7" },
   { path: "/deletion-distributed-systems-contract", changefreq: "monthly", priority: "0.8" },
   { path: "/building-ephemeral-chat-cloudflare", changefreq: "monthly", priority: "0.8" },
-  { path: "/durable-objects-websocket-hibernation", changefreq: "monthly", priority: "0.8" }
+  { path: "/durable-objects-websocket-hibernation", changefreq: "monthly", priority: "0.8" },
+  { path: "/cloudflare-deploy-button-monorepo", changefreq: "monthly", priority: "0.8" }
 ];
 
 const lastmod = new Date().toISOString().slice(0, 10);

--- a/apps/web/scripts/prerender-marketing.mjs
+++ b/apps/web/scripts/prerender-marketing.mjs
@@ -742,6 +742,77 @@ Invariant: no transition leaves DESTROYED or RECLAIMED.</code></pre>
         <p><a href="https://github.com/shawnbure/elm-chat">Read the source and deployment guide</a>.</p>
       </section>`
   },
+  "cloudflare-deploy-button-monorepo": {
+    title:
+      "Fixing Deploy to Cloudflare in a monorepo: expose the root contract",
+    description:
+      "Why Deploy to Cloudflare misses nested Wrangler configuration, and how root scripts, a root config, drift checks, and public-path testing fix it.",
+    eyebrow: "Cloudflare deployment field note",
+    byline: "By Shawn Bure — creator of elm.chat",
+    authorName: "Shawn Bure",
+    authorUrl: "https://shawnbure.com/",
+    datePublished: "2026-08-05",
+    dateModified: "2026-08-05",
+    schemaType: "TechArticle",
+    socialImage: "elm-chat-architecture-social.png",
+    socialImageAlt:
+      "Cloudflare deployment architecture — a monorepo root contract delegates to web and Worker workspaces",
+    keywords: [
+      "Deploy to Cloudflare",
+      "Cloudflare deploy button",
+      "Cloudflare monorepo",
+      "No Wrangler configuration detected",
+      "Wrangler configuration",
+      "npm workspaces",
+      "Cloudflare Workers",
+    ],
+    developerAudience: true,
+    intro:
+      "A deploy badge can look correct while every new user reaches “No Wrangler configuration detected.” In a workspace repository, the fix is to make the target root a complete deployment contract.",
+    body: `
+      <section>
+        <h2>The failure appears after the badge works</h2>
+        <p>elm.chat already had a working production deployment and a valid Deploy to Cloudflare link. Its Wrangler configuration lived under <code>workers/api</code>, where local and production commands could find it. A new visitor followed the badge, however, and Cloudflare reported <strong>No Wrangler configuration detected</strong> before falling back to automatic project configuration.</p>
+        <p>That is the dangerous version of a deployment bug: maintainers can keep shipping while the public self-host path is broken. The badge tests only navigation. It does not prove that the target directory exposes everything the setup flow needs.</p>
+      </section>
+      <section>
+        <h2>The target directory is the contract boundary</h2>
+        <p>Cloudflare analyzes the directory named by the deploy URL. If the URL targets the repository root, nested workspace configuration is not a substitute for a root deploy contract. The root needs a Wrangler configuration plus build and deploy scripts that work from that directory.</p>
+        <pre><code>{
+  &quot;scripts&quot;: {
+    &quot;build&quot;: &quot;npm run build --workspace @example/web &amp;&amp; npm run build --workspace @example/api&quot;,
+    &quot;deploy&quot;: &quot;npm run build &amp;&amp; wrangler deploy -c wrangler.jsonc&quot;
+  }
+}</code></pre>
+        <p>The root scripts can delegate to workspaces. What matters is that a stranger—and Cloudflare's project analysis—can start at the target root without knowing the repository's internal layout.</p>
+      </section>
+      <section>
+        <h2>Keep the public template smaller than production when necessary</h2>
+        <p>elm.chat's production Worker uses an optional Analytics Engine binding for its own aggregate growth measurement. Cloudflare does not list Analytics Engine among the resources its deploy button automatically provisions, so the public root template omits that binding. Independent instances work without sending elm.chat measurement events.</p>
+        <p>Do not copy every production binding into a one-click template by reflex. Include only resources the platform can provision or the deployer can supply during setup. Otherwise the button turns an optional integration into a first-run failure.</p>
+      </section>
+      <section>
+        <h2>Two configurations require a drift test</h2>
+        <p>A root template and a workspace production configuration can quietly diverge. elm.chat runs a repository check that compares the Worker entry point, Durable Object binding, migration tag, assets directory, compatibility date, and resolved paths. The build fails if the shared runtime contract drifts.</p>
+        <p>This keeps intentional differences explicit: production can retain an optional binding, while the independently deployable root template stays minimal and reproducible.</p>
+      </section>
+      <section>
+        <h2>Test the public journey, not the maintainer journey</h2>
+        <ol>
+          <li>Open the public repository as a visitor would.</li>
+          <li>Follow the published deploy button rather than a private dashboard shortcut.</li>
+          <li>Select an account and wait for repository analysis.</li>
+          <li>Confirm the detected build command, deploy command, and root path.</li>
+          <li>Stop and investigate if the fallback warning appears.</li>
+          <li>Run both root and workspace Wrangler dry runs in continuous integration.</li>
+        </ol>
+        <p>Cloudflare documents the supported button format, scripts, and provisioned resources in its <a href="https://developers.cloudflare.com/workers/platform/deploy-buttons/">Deploy to Cloudflare guide</a>. The elm.chat repair is public in <a href="https://github.com/shawnbure/elm-chat/pull/89">pull request 89</a>, including its root configuration and parity check.</p>
+      </section>
+      <section>
+        <h2>The reusable lesson</h2>
+        <p>A one-click deploy feature is an external API. Its callers do not share the maintainer's working directory, cached settings, or mental model. Treat the target root as a stable interface, make every dependency visible there, and test it from the outside.</p>
+      </section>`,
+  },
   "durable-objects-websocket-hibernation": {
     title: "Durable Objects WebSocket hibernation without a chat database",
     description:
@@ -831,7 +902,8 @@ const guideLabels = {
   "why-i-built-elm-chat": "Why I built elm.chat",
   "deletion-distributed-systems-contract": "Deletion as a distributed-systems contract",
   "building-ephemeral-chat-cloudflare": "How elm.chat works on Cloudflare",
-  "durable-objects-websocket-hibernation": "WebSocket hibernation without a chat database"
+  "durable-objects-websocket-hibernation": "WebSocket hibernation without a chat database",
+  "cloudflare-deploy-button-monorepo": "Fix Deploy to Cloudflare in a monorepo"
 };
 
 for (const [slug, page] of Object.entries(pages)) {

--- a/apps/web/scripts/submit-indexnow.mjs
+++ b/apps/web/scripts/submit-indexnow.mjs
@@ -16,7 +16,8 @@ const urlList = [
   `https://${host}/why-i-built-elm-chat`,
   `https://${host}/deletion-distributed-systems-contract`,
   `https://${host}/building-ephemeral-chat-cloudflare`,
-  `https://${host}/durable-objects-websocket-hibernation`
+  `https://${host}/durable-objects-websocket-hibernation`,
+  `https://${host}/cloudflare-deploy-button-monorepo`
 ];
 
 const response = await fetch("https://api.indexnow.org/indexnow", {

--- a/apps/web/src/MarketingPage.tsx
+++ b/apps/web/src/MarketingPage.tsx
@@ -1334,6 +1334,150 @@ Invariant: no transition leaves DESTROYED or RECLAIMED.`}</code>
       </>
     )
   },
+  "cloudflare-deploy-button-monorepo": {
+    developerAudience: true,
+    byline: "By Shawn Bure — creator of elm.chat",
+    title:
+      "Fixing Deploy to Cloudflare in a monorepo: expose the root contract",
+    description:
+      "Why Deploy to Cloudflare misses nested Wrangler configuration, and how root scripts, a root config, drift checks, and public-path testing fix it.",
+    eyebrow: "Cloudflare deployment field note",
+    intro:
+      "A deploy badge can look correct while every new user reaches “No Wrangler configuration detected.” In a workspace repository, the fix is to make the target root a complete deployment contract.",
+    body: (
+      <>
+        <section>
+          <h2>The failure appears after the badge works</h2>
+          <p>
+            elm.chat already had a working production deployment and a valid
+            Deploy to Cloudflare link. Its Wrangler configuration lived under{" "}
+            <code>workers/api</code>, where local and production commands could
+            find it. A new visitor followed the badge, however, and Cloudflare
+            reported <strong>No Wrangler configuration detected</strong> before
+            falling back to automatic project configuration.
+          </p>
+          <p>
+            That is the dangerous version of a deployment bug: maintainers can
+            keep shipping while the public self-host path is broken. The badge
+            tests only navigation. It does not prove that the target directory
+            exposes everything the setup flow needs.
+          </p>
+        </section>
+
+        <section>
+          <h2>The target directory is the contract boundary</h2>
+          <p>
+            Cloudflare analyzes the directory named by the deploy URL. If the
+            URL targets the repository root, nested workspace configuration is
+            not a substitute for a root deploy contract. The root needs a
+            Wrangler configuration plus build and deploy scripts that work from
+            that directory.
+          </p>
+          <pre>
+            <code>{`{
+  "scripts": {
+    "build": "npm run build --workspace @example/web && npm run build --workspace @example/api",
+    "deploy": "npm run build && wrangler deploy -c wrangler.jsonc"
+  }
+}`}</code>
+          </pre>
+          <p>
+            The root scripts can delegate to workspaces. What matters is that a
+            stranger—and Cloudflare&apos;s project analysis—can start at the
+            target root without knowing the repository&apos;s internal layout.
+          </p>
+        </section>
+
+        <section>
+          <h2>
+            Keep the public template smaller than production when necessary
+          </h2>
+          <p>
+            elm.chat&apos;s production Worker uses an optional Analytics Engine
+            binding for its own aggregate growth measurement. Cloudflare does
+            not list Analytics Engine among the resources its deploy button
+            automatically provisions, so the public root template omits that
+            binding. Independent instances work without sending elm.chat
+            measurement events.
+          </p>
+          <p>
+            Do not copy every production binding into a one-click template by
+            reflex. Include only resources the platform can provision or the
+            deployer can supply during setup. Otherwise the button turns an
+            optional integration into a first-run failure.
+          </p>
+        </section>
+
+        <section>
+          <h2>Two configurations require a drift test</h2>
+          <p>
+            A root template and a workspace production configuration can quietly
+            diverge. elm.chat runs a repository check that compares the Worker
+            entry point, Durable Object binding, migration tag, assets
+            directory, compatibility date, and resolved paths. The build fails
+            if the shared runtime contract drifts.
+          </p>
+          <p>
+            This keeps intentional differences explicit: production can retain
+            an optional binding, while the independently deployable root
+            template stays minimal and reproducible.
+          </p>
+        </section>
+
+        <section>
+          <h2>Test the public journey, not the maintainer journey</h2>
+          <ol>
+            <li>Open the public repository as a visitor would.</li>
+            <li>
+              Follow the published deploy button rather than a private dashboard
+              shortcut.
+            </li>
+            <li>Select an account and wait for repository analysis.</li>
+            <li>
+              Confirm the detected build command, deploy command, and root path.
+            </li>
+            <li>Stop and investigate if the fallback warning appears.</li>
+            <li>
+              Run both root and workspace Wrangler dry runs in continuous
+              integration.
+            </li>
+          </ol>
+          <p>
+            Cloudflare documents the supported button format, scripts, and
+            provisioned resources in its{" "}
+            <a
+              href="https://developers.cloudflare.com/workers/platform/deploy-buttons/"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Deploy to Cloudflare guide
+            </a>
+            . The elm.chat repair is public in{" "}
+            <a
+              href="https://github.com/shawnbure/elm-chat/pull/89"
+              rel="noreferrer"
+              target="_blank"
+            >
+              pull request 89
+            </a>
+            , including its root configuration and parity check.
+          </p>
+        </section>
+
+        <section>
+          <h2>The reusable lesson</h2>
+          <p>
+            A one-click deploy feature is an external API. Its callers do not
+            share the maintainer&apos;s working directory, cached settings, or
+            mental model. Treat the target root as a stable interface, make
+            every dependency visible there, and test it from the outside.
+          </p>
+        </section>
+
+        <Limitations />
+      </>
+    ),
+  },
   "durable-objects-websocket-hibernation": {
     developerAudience: true,
     byline: "By Shawn Bure — creator of elm.chat",
@@ -1637,6 +1781,10 @@ function RelatedGuides({ current }: { current: MarketingSlug }) {
     {
       slug: "durable-objects-websocket-hibernation",
       label: "WebSocket hibernation without a chat database"
+    },
+    {
+      slug: "cloudflare-deploy-button-monorepo",
+      label: "Fix Deploy to Cloudflare in a monorepo"
     }
   ];
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,7 +30,8 @@ export const MARKETING_ACQUISITION_SOURCES = [
   "why-i-built-elm-chat",
   "deletion-distributed-systems-contract",
   "building-ephemeral-chat-cloudflare",
-  "durable-objects-websocket-hibernation"
+  "durable-objects-websocket-hibernation",
+  "cloudflare-deploy-button-monorepo"
 ] as const;
 
 export const EXTERNAL_ACQUISITION_SOURCES = [


### PR DESCRIPTION
## What changed

- Adds a focused technical guide for the verified `No Wrangler configuration detected` failure in workspace repositories.
- Explains the root deployment contract, intentional production/template differences, configuration-drift testing, and public-path validation.
- Adds the guide to typed marketing routes, related guides, `TechArticle` metadata, RSS, sitemap, IndexNow, and `llms.txt`.

## Why

elm.chat's self-host loop exposed a real failure: a valid deploy badge and working maintainer deployment did not prove that Cloudflare could analyze the public repository root. The article turns that repair into a reusable, search-focused field note for other Workers developers.

## Validation

- `npm run typecheck`
- `npm run build`
- `npx wrangler deploy --dry-run -c wrangler.jsonc`
- Rendered canonical, `TechArticle` author metadata, RSS, sitemap, and `llms.txt` checks.
- `git diff --check`

The guide uses US English and keeps elm.chat's security limitations explicit.
