### PR TITLE
Separate hosted and public deployment commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Notes:
 - **workers.dev subdomain.** The first time you deploy to an account, Cloudflare may ask you to register a free `*.workers.dev` subdomain (in the dashboard under **Workers & Pages**). Do that once, then re-run `npm run deploy`.
 - **Durable Object migration.** The `migrations` block in `wrangler.jsonc` creates the `RoomDurableObject` SQLite class automatically on first deploy — no manual step.
 - **Two checked Wrangler entry points.** Root `wrangler.jsonc` is the Deploy-to-Cloudflare entry point; `workers/api/wrangler.jsonc` remains the production/API workspace entry point. The root template intentionally omits elm.chat's optional growth-measurement dataset because Cloudflare does not list Analytics Engine among the resources its deploy button auto-provisions. Self-hosted instances work without that dataset and do not send elm.chat growth events. `npm run check:wrangler-configs` fails if the runtime resources or resolved paths drift.
+- **Maintainer production deployment.** The hosted `elm.chat` instance uses `npm run deploy:production`, which selects `workers/api/wrangler.jsonc` and preserves the optional aggregate Analytics Engine binding. Independent self-hosters should continue to use `npm run deploy`; it intentionally uses the smaller public template.
 - **Renaming.** To run multiple instances or avoid a name clash, change `"name"` in both Wrangler configuration files before deploying.
 - **Redeploying after changes.** Just run `npm run deploy` again — it rebuilds `apps/web/dist` before deploying.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dev": "concurrently -k -n api,web -c blue,green \"npm:dev:api\" \"npm:dev:web\"",
     "dev:web": "npm run dev --workspace @elm-chat/web",
     "dev:api": "npm run dev --workspace @elm-chat/api",
-    "deploy": "npm run check:wrangler-configs && npm run build --workspace @elm-chat/web && CLOUDFLARE_ACCOUNT_ID=\"${ELM_CHAT_CLOUDFLARE_ACCOUNT_ID:-$CLOUDFLARE_ACCOUNT_ID}\" wrangler deploy -c wrangler.jsonc"
+    "deploy": "npm run check:wrangler-configs && npm run build --workspace @elm-chat/web && CLOUDFLARE_ACCOUNT_ID=\"${ELM_CHAT_CLOUDFLARE_ACCOUNT_ID:-$CLOUDFLARE_ACCOUNT_ID}\" wrangler deploy -c wrangler.jsonc",
+    "deploy:production": "npm run check:wrangler-configs && npm run build --workspace @elm-chat/web && npm run deploy --workspace @elm-chat/api"
   },
   "devDependencies": {
     "concurrently": "^9.1.2",


### PR DESCRIPTION
Adds an explicit deploy:production command that uses the production workspace Wrangler configuration and preserves elm.chat's aggregate Analytics Engine binding. Keeps npm run deploy unchanged for independent self-hosters using the smaller public template.\n\nVerification:\n- npm run typecheck\n- npm run build\n- production workspace dry run shows ROOM_OBJECT, GROWTH, and ASSETS\n- git diff --check