### PR TITLE
Track LinkedIn acquisition source

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -47,6 +47,7 @@ export const EXTERNAL_ACQUISITION_SOURCES = [
   "high-scalability",
   "llms-txt",
   "linuxlinks",
+  "linkedin",
   "reddit-cloudflare",
   "reddit-selfhosted",
   "sre-weekly",


### PR DESCRIPTION
## What changed
- accept `linkedin` in the closed external acquisition source list
- preserve the existing aggregate-only attribution model

## Why
LinkedIn posts already use `?source=linkedin`, but the API did not accept that value. This makes the next distribution test measurable without adding cookies or person-level tracking.

## Verification
- `npm run typecheck`
- `npm run build`
- production API Wrangler dry run
- `git diff --check`