### PR TITLE
Add self-host deployment feedback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ elm.chat is Cloudflare-native, so you can fork and self-host a full private inst
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://elm.chat/deploy/cloudflare?source=github-readme)
 
+Tried the self-host path? [Share a successful deployment or the exact blocker](https://github.com/shawnbure/elm-chat/discussions/97). Self-hosted instances send no analytics back to elm.chat, so this opt-in report is the only reliable way to improve the path for the next operator.
+
 Prefer to do it by hand? See [Deploy to Cloudflare](#deploy-to-cloudflare) below. Want to contribute instead of just run it? Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the [good first issues](docs/GOOD-FIRST-ISSUES.md).
 
 ![elm.chat landing page](docs/images/landing-page.jpg)


### PR DESCRIPTION
## What changed
- link the README deploy section to a new opt-in Show and tell discussion
- explain why self-hosted instances do not report analytics back to elm.chat
- invite successful deployment reports and exact blockers without requesting secrets

## Why
The last 24 hours produced three aggregate Deploy-to-Cloudflare clicks, but independent instances intentionally omit elm.chat analytics. This creates a privacy-respecting way to collect credible deployment evidence and improve the self-host loop.

## Verification
- discussion URL returns HTTP 200
- discussion category and content verified through GitHub API
- `git diff --check`
- US-English copy audit